### PR TITLE
Introduce readStyle implementation for basic support for OL Styles 

### DIFF
--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -6,15 +6,18 @@ import point_simplepoint from '../data/styles/point_simplepoint';
 import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
-import { CircleSymbolizer, LineSymbolizer, FillSymbolizer, TextSymbolizer } from 'geostyler-style';
+import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
+import ol_line_simpleline from '../data/olStyles/line_simpleline';
+import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
+import { CircleSymbolizer, LineSymbolizer, FillSymbolizer, TextSymbolizer, Style } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
 
-it('SldStyleParser is defined', () => {
+it('OlStyleParser is defined', () => {
   expect(OlStyleParser).toBeDefined();
 });
 
-describe('SldStyleParser implements StyleParser', () => {
+describe('OlStyleParser implements StyleParser', () => {
   let styleParser: OlStyleParser;
 
   beforeEach(() => {
@@ -26,56 +29,65 @@ describe('SldStyleParser implements StyleParser', () => {
       expect(styleParser.readStyle).toBeDefined();
     });
     it('can read a OpenLayers PointSymbolizer', () => {
-      // expect.assertions(2);
-      // const sld = fs.readFileSync( './data/slds/point_simplepoint.sld', 'utf8');
-      // return styleParser.readStyle(sld)
-      //   .then((geoStylerStyle: Style) => {
-      //     expect(geoStylerStyle).toBeDefined();
-      //     expect(geoStylerStyle).toEqual(point_simplepoint);
-      //   });
+      expect.assertions(2);
+      return styleParser.readStyle(ol_point_simplepoint)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplepoint);
+        });
     });
     it('can read a OpenLayers LineSymbolizer', () => {
-      // expect.assertions(2);
-      // const sld = fs.readFileSync( './data/slds/line_simpleline.sld', 'utf8');
-      // return styleParser.readStyle(sld)
-      // .then((geoStylerStyle: Style) => {
-      //   expect(geoStylerStyle).toBeDefined();
-      //   expect(geoStylerStyle).toEqual(line_simpleline);
-      // });
+      expect.assertions(2);
+      return styleParser.readStyle(ol_line_simpleline)
+      .then((geoStylerStyle: Style) => {
+        expect(geoStylerStyle).toBeDefined();
+        expect(geoStylerStyle).toEqual(line_simpleline);
+      });
     });
     it('can read a OpenLayers PolygonSymbolizer', () => {
-      // expect.assertions(2);
-      // const sld = fs.readFileSync( './data/slds/polygon_transparentpolygon.sld', 'utf8');
-      // return styleParser.readStyle(sld)
-      // .then((geoStylerStyle: Style) => {
-      //   expect(geoStylerStyle).toBeDefined();
-      //   expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
-      //   });
+      expect.assertions(2);
+      return styleParser.readStyle(ol_polygon_transparentpolygon)
+      .then((geoStylerStyle: Style) => {
+        expect(geoStylerStyle).toBeDefined();
+        expect(geoStylerStyle).toEqual(polygon_transparentpolygon);
+      });
     });
-    it('can read a OpenLayers TextSymbolizer', () => {
-      // expect.assertions(2);
-      // const sld = fs.readFileSync( './data/slds/point_styledlabel.sld', 'utf8');
-      // return styleParser.readStyle(sld)
-      //   .then((geoStylerStyle: Style) => {
-      //     expect(geoStylerStyle).toBeDefined();
-      //     expect(geoStylerStyle).toEqual(point_styledlabel);
-      //   });
-    });
-    it('can read a OpenLayers style with a filter', () => {
-      // expect.assertions(2);
-      // const sld = fs.readFileSync( './data/slds/point_simplepoint_filter.sld', 'utf8');
-      // return styleParser.readStyle(sld)
-      //   .then((geoStylerStyle: Style) => {
-      //     expect(geoStylerStyle).toBeDefined();
-      //     expect(geoStylerStyle).toEqual(point_simplepoint_filter);
-      //   });
+    // it('can read a OpenLayers TextSymbolizer', () => {
+    //   expect.assertions(2);
+    //   const sld = fs.readFileSync( './data/slds/point_styledlabel.sld', 'utf8');
+    //   return styleParser.readStyle(sld)
+    //     .then((geoStylerStyle: Style) => {
+    //       expect(geoStylerStyle).toBeDefined();
+    //       expect(geoStylerStyle).toEqual(point_styledlabel);
+    //     });
+    // });
+    // it('can read a OpenLayers style with a filter', () => {
+    //   expect.assertions(2);
+    //   const sld = fs.readFileSync( './data/slds/point_simplepoint_filter.sld', 'utf8');
+    //   return styleParser.readStyle(sld)
+    //     .then((geoStylerStyle: Style) => {
+    //       expect(geoStylerStyle).toBeDefined();
+    //       expect(geoStylerStyle).toEqual(point_simplepoint_filter);
+    //     });
+    // });
+
+    describe('#getStyleTypeFromOlStyle', () => {
+      it('is defined', () => {
+        expect(styleParser.getStyleTypeFromOlStyle).toBeDefined();
+      });
     });
 
-    // describe('#getStyleTypeFromOlStyle', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getStyleTypeFromOlStyle).toBeDefined();
-    //   });
-    // });
+    describe('#getRulesFromOlStyle', () => {
+      it('is defined', () => {
+        expect(styleParser.getRulesFromOlStyle).toBeDefined();
+      });
+    });
+
+    describe('#getSymbolizerFromOlStyle', () => {
+      it('is defined', () => {
+        expect(styleParser.getSymbolizerFromOlStyle).toBeDefined();
+      });
+    });
 
     // describe('#getFilterFromOperatorAndComparison', () => {
     //   it('is defined', () => {
@@ -95,47 +107,29 @@ describe('SldStyleParser implements StyleParser', () => {
     //   });
     // });
 
-    // describe('#getPointSymbolizerFromSldSymbolizer', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getPointSymbolizerFromSldSymbolizer).toBeDefined();
-    //   });
-    // });
+    describe('#getPointSymbolizerFromOlSymbolizer', () => {
+      it('is defined', () => {
+        expect(styleParser.getPointSymbolizerFromOlStyle).toBeDefined();
+      });
+    });
 
     describe('#getLineSymbolizerFromOlSymbolizer', () => {
-      // it('is defined', () => {
-      //   expect(styleParser.getLineSymbolizerFromOlSymbolizer).toBeDefined();
-      // });
+      it('is defined', () => {
+        expect(styleParser.getLineSymbolizerFromOlStyle).toBeDefined();
+      });
     });
 
     describe('#getFillSymbolizerFromOlSymbolizer', () => {
-      // it('is defined', () => {
-      //   expect(styleParser.getFillSymbolizerFromSldSymbolizer).toBeDefined();
-      // });
+      it('is defined', () => {
+        expect(styleParser.getFillSymbolizerFromOlStyle).toBeDefined();
+      });
     });
 
-    describe('#getTextSymbolizerFromOlSymbolizer', () => {
-      // it('is defined', () => {
-      //   expect(styleParser.getTextSymbolizerFromOlSymbolizer).toBeDefined();
-      // });
-    });
-
-    // describe('#getSymbolizerFromRule', () => {
+    // describe('#getTextSymbolizerFromOlSymbolizer', () => {
     //   it('is defined', () => {
-    //     expect(styleParser.getSymbolizerFromRule).toBeDefined();
+    //     expect(styleParser.getTextSymbolizerFromOlSymbolizer).toBeDefined();
     //   });
     // });
-
-    // describe('#getRulesFromSldObject', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getRulesFromSldObject).toBeDefined();
-    //   });
-    // });
-
-    describe('#olObjectToGeoStylerStyle', () => {
-      // it('is defined', () => {
-      //   expect(styleParser.olObjectToGeoStylerStyle).toBeDefined();
-      // });
-    });
   });
 
   describe('#writeStyle', () => {
@@ -244,17 +238,11 @@ describe('SldStyleParser implements StyleParser', () => {
     //     });
     // });
 
-    // describe('#geoStylerStyleToOlObject', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.geoStylerStyleToOlObject).toBeDefined();
-    //   });
-    // });
-
-    // describe('#getSldRulesFromRules', () => {
-    //   it('is defined', () => {
-    //     expect(styleParser.getSldRulesFromRules).toBeDefined();
-    //   });
-    // });
+    describe('#getRulesFromOlStyle', () => {
+      it('is defined', () => {
+        expect(styleParser.getRulesFromOlStyle).toBeDefined();
+      });
+    });
 
     describe('#getOlSymbolizerFromSymbolizer', () => {
       it('is defined', () => {

--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -1,0 +1,85 @@
+import OlStyleUtil from './OlStyleUtil';
+import { TextSymbolizer } from 'geostyler-style';
+
+describe('OlStyleUtil', () => {
+  
+  it('OlStyleUtil is defined', () => {
+    expect(OlStyleUtil).toBeDefined();
+  });
+
+  describe('#getRgbaColor', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getRgbaColor).toBeDefined();
+    });
+
+    it('transforms correctly', () => {
+      const rgba = OlStyleUtil.getRgbaColor('#808a08', 0.5);
+      expect(rgba).toEqual('rgba(128, 138, 8, 0.5)');
+    });
+  });
+
+  describe('#splitRgbaColor', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.splitRgbaColor).toBeDefined();
+    });
+
+    it('transforms correctly', () => {
+      const splitted = OlStyleUtil.splitRgbaColor('rgba(128, 138, 8, 0.5)');
+      expect(splitted).toEqual([128, 138, 8, 0.5]);
+    });
+  });
+
+  describe('#getHexColor', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getHexColor).toBeDefined();
+    });
+
+    it('transforms rgb correctly', () => {
+      const hex = OlStyleUtil.getHexColor('rgb(128, 138, 8)');
+      expect(hex).toEqual('#808a08');
+    });
+    it('transforms rgba correctly', () => {
+      const hex = OlStyleUtil.getHexColor('rgba(128, 138, 8, 0.5)');
+      expect(hex).toEqual('#808a08');
+    });
+    it('returns given hex untransformed', () => {
+      const hex = OlStyleUtil.getHexColor('#808a08');
+      expect(hex).toEqual('#808a08');
+    });
+  });
+
+  describe('#getOpacity', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getOpacity).toBeDefined();
+    });
+
+    it('returns correct opacity', () => {
+      const opac = OlStyleUtil.getOpacity('rgba(128, 138, 8, 0.5)');
+      expect(opac).toEqual(0.5);
+    });
+    it('returns undefined when input is incorrect', () => {
+      const opac = OlStyleUtil.getOpacity('rgb(128, 138, 8)');
+      expect(opac).toBeUndefined();
+    });
+  });
+
+  describe('#getTextFont', () => {
+    it('is defined', () => {
+      expect(OlStyleUtil.getTextFont).toBeDefined();
+    });
+
+    it('returns correct opacity', () => {
+      const symb: TextSymbolizer = {
+        kind: 'Text',
+        color: '#000000',
+        field: 'name',
+        font: ['Arial'],
+        size: 12,
+        offset: [0, 5]
+      };
+      const opac = OlStyleUtil.getTextFont(symb);
+      expect(opac).toEqual('Normal 12px Arial');
+    });
+  });
+
+});

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -93,10 +93,11 @@ class OlStyleUtil {
    * @param symbolizer The TextSymbolizer to derive the font string from
    */
   public static getTextFont(symbolizer: TextSymbolizer) {
+    // since TextSymbolizer has no prop for font weight we use 'Normal' as default
     const weight = 'Normal';
     const size = symbolizer.size;
     const font = symbolizer.font;
-    return weight + ' ' + size + ' ' + font;
+    return weight + ' ' + size + 'px ' + font;
   }
 }
 

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -6,10 +6,11 @@ import { TextSymbolizer } from 'geostyler-style';
 class OlStyleUtil {
 
   /**
-   * Transforms a HEX encoded color and an opacity value to a RGBA notation.
+   * Transforms a HEX encoded color and an opacity value to a RGB(A) notation.
    *
-   * @param hexColor HEX encoded color
-   * @param opacity  Opacity (Betweeen 0 and 1)
+   * @param {string} hexColor HEX encoded color
+   * @param {number} opacity  Opacity (Betweeen 0 and 1)
+   * @return {string} the RGB(A) value of the input color
    */
   public static getRgbaColor(hexColor: string, opacity: number) {
     const r = parseInt(hexColor.slice(1, 3), 16);
@@ -24,7 +25,70 @@ class OlStyleUtil {
   }
 
   /**
-   * Returns an OL cpmpliant font string.
+   * Splits a RGBA encoded color into its color values.
+   *
+   * @param {string} rgbaColor RGB(A) encoded color
+   * @return {number[]} Numeric color values as array
+   */
+  public static splitRgbaColor(rgbaColor: string): number[] {
+    const colorsOnly = rgbaColor.substring(rgbaColor.indexOf('(') + 1, rgbaColor.lastIndexOf(')')).split(/,\s*/);
+    const red = parseInt(colorsOnly[0], 10);
+    const green = parseInt(colorsOnly[1], 10);
+    const blue = parseInt(colorsOnly[2], 10);
+    const opacity = parseFloat(colorsOnly[3]);
+
+    return [red, green, blue, opacity];
+  }
+
+  /**
+   * Transforms a RGB(A) color value to a HEX encoded notation.
+   * If a HEX color is provided it will be returned untransformed.
+   *
+   * @param {string} inColor The color to transform
+   * @return {string | undefined} The HEX color representation of the given color
+   */
+  public static getHexColor(inColor: string): string | undefined {
+    // if passing in a hex code we just return it
+    if (inColor.startsWith('#')) {
+      return inColor;
+    } else if (inColor.startsWith('rgb')) {
+      const colorArr = OlStyleUtil.splitRgbaColor(inColor);
+
+      return '#' + colorArr.map((x, idx) => {
+        const hex = x.toString(16);
+        // skip opeacity of available
+        if (idx < 3) {
+          // return hex;
+          return hex.length === 1 ? '0' + hex : hex;
+        }
+      }).join('');
+    } else {
+      return;
+    }
+  }
+
+  /**
+   * Returns the opacity value of a RGB(A) color value.
+   *
+   * @param rgbaColor RGBA encoded color
+   * @return {string | undefined} The opacity value of the given RGBA color
+   */
+  public static getOpacity(rgbaColor: string): number | undefined {
+    if (!rgbaColor.startsWith('rgba(')) {
+      return;
+    }
+
+    const colorArr = OlStyleUtil.splitRgbaColor(rgbaColor);
+
+    if (colorArr.length === 4) {
+      return colorArr[3];
+    } else {
+      return;
+    }
+  }
+
+  /**
+   * Returns an OL compliant font string.
    *
    * @param symbolizer The TextSymbolizer to derive the font string from
    */


### PR DESCRIPTION
This implements the ``readStyle`` function by adding a basic parser functionality to read OpenLayers Style objects. 

Supported Symbolizer Types: ``Point``, ``Line`` and ``Fill``.