### PR TITLE
Transform label value to string in OL-Style-Func

### DIFF
--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -224,6 +224,32 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olTextOffsetY).toEqual(expectedOffsetY);
         });
     });
+    it('transforms labels values based on fields to string ', () => {
+      expect.assertions(4);
+      // change the field as base for the label text to a numeric one
+      const inSymb = point_styledlabel.rules[0].symbolizer as TextSymbolizer;
+      inSymb.field = 'id';
+      return styleParser.writeStyle(point_styledlabel)
+        .then((olStyles: ol.style.Style[] | ol.StyleFunction[]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_styledlabel.rules[0].symbolizer as TextSymbolizer;
+
+          const dummyFeat = new ol.Feature({
+            id: 1
+          });
+          const olStyleFn = olStyles[0] as ol.StyleFunction;
+          expect(olStyleFn).toBeDefined();
+          // execute the returned StyleFunction and get the underlying OL style object
+          const olStyle: ol.style.Style = olStyleFn(dummyFeat, 1) as ol.style.Style;
+
+          const olText = olStyle.getText();
+          const olTextContent = olText.getText();
+          expect(typeof olTextContent).toEqual('string');
+          expect(olTextContent).toEqual(dummyFeat.get('id') + '');
+
+        });
+    });
     // it('can write a OpenLayers style with a filter', () => {
     //   expect.assertions(2);
     //   return styleParser.writeStyle(point_simplepoint_filter)

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -357,7 +357,7 @@ class OlStyleParser implements StyleParser {
 
       const text = new ol.style.Text({
         font: OlStyleUtil.getTextFont(symbolizer),
-        text: feature.get(symbolizer.field || ''),
+        text: feature.get(symbolizer.field || '') + '',
         fill: new ol.style.Fill({
           color: (symbolizer.color && symbolizer.opacity) ?
             OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color


### PR DESCRIPTION
Transforms the text for a label by a non-string attribute field to a string value. Transformation is done in the OpenLayers Style Function.

Related to https://github.com/terrestris/geostyler/issues/194.