### PR TITLE
Apply demo data for unit tests due to gs-style v0.6.0

### DIFF
--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -2,8 +2,10 @@ import { Style } from 'geostyler-style';
 
 const pointSimplePoint: Style = {
   type: 'Point',
+  name: 'OL Style',
   rules: [
     {
+      name: 'OL Style Rule',
       filter: ['&&',
         ['==', 'NAME', 'New York'],
         ['!',

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -2,8 +2,10 @@ import { Style } from 'geostyler-style';
 
 const pointStyledLabel: Style = {
   type: 'Point',
+  name: 'OL Style',
   rules: [
     {
+      name: 'OL Style Rule',
       symbolizer: {
         kind: 'Text',
         color: '#000000',


### PR DESCRIPTION
Due to the new version 0.6.0 of [GeoStyler Style](https://github.com/terrestris/geostyler-style), this corrects all demo data for the unit tests.