### PR TITLE
Introduces getOlIconSymbolizerFromIconSymbolizer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "port": 9230,
+      "runtimeArgs": [
+        "--inspect-brk=9230",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--watch"
+      ],
+      "runtimeExecutable": null,
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Tests Windows",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest",
+      "args": [
+        "-i",
+        "--watch"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "console": "integratedTerminal",
+      "outFiles": [
+        "${workspaceRoot}/build/dist/**/*"
+      ]
+    }
+  ]
+}

--- a/data/olStyles/point_icon.ts
+++ b/data/olStyles/point_icon.ts
@@ -1,0 +1,12 @@
+import * as ol from 'openlayers';
+
+const olIconPoint = new ol.style.Style({
+  image: new ol.style.Icon({
+    src: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
+    scale: 0.1,
+    rotation: 0.7853981633974483,
+    opacity: 0.5
+  })
+});
+
+export default olIconPoint;

--- a/data/styles/point_icon.ts
+++ b/data/styles/point_icon.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  type: 'Point',
+  name: 'OL Icon Style',
+  rules: [
+    {
+      name: 'OL Style Rule',
+      symbolizer: {
+        kind: 'Icon',
+        image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
+        size: 0.4,
+        opacity: 0.5,
+        rotate: 45
+      }
+    }
+  ]
+};
+
+export default pointSimplePoint;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -152,11 +152,11 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olStyles).toBeDefined();
 
           const expecSymb = point_simplepoint.rules[0].symbolizer as CircleSymbolizer;
-          const olImage: ol.style.Circle = olStyles[0].getImage() as ol.style.Circle;
+          const olCircle: ol.style.Circle = olStyles[0].getImage() as ol.style.Circle;
 
-          expect(olImage).toBeDefined();
-          expect(olImage.getRadius()).toEqual(expecSymb.radius);
-          expect(olImage.getFill().getColor()).toEqual(expecSymb.color);
+          expect(olCircle).toBeDefined();
+          expect(olCircle.getRadius()).toEqual(expecSymb.radius);
+          expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
         });
     });
     it('can write a OpenLayers IconSymbolizer', () => {
@@ -166,15 +166,15 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olStyles).toBeDefined();
 
           const expecSymb = point_icon.rules[0].symbolizer as IconSymbolizer;
-          const olImage: ol.style.Icon = olStyles[0].getImage() as ol.style.Icon;
+          const olIcon: ol.style.Icon = olStyles[0].getImage() as ol.style.Icon;
 
-          expect(olImage.getSrc()).toEqual(expecSymb.image);
-          expect(olImage.getScale()).toEqual(expecSymb.size);
+          expect(olIcon.getSrc()).toEqual(expecSymb.image);
+          expect(olIcon.getScale()).toEqual(expecSymb.size);
           // Rotation in openlayers is radians while we use degree
-          expect(olImage.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
-          expect(olImage.getOpacity()).toEqual(expecSymb.opacity);
+          expect(olIcon.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olIcon.getOpacity()).toEqual(expecSymb.opacity);
 
-          expect(olImage).toBeDefined();
+          expect(olIcon).toBeDefined();
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -3,13 +3,22 @@ import * as ol from 'openlayers';
 import OlStyleParser from './OlStyleParser';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
+import point_icon from '../data/styles/point_icon';
 import line_simpleline from '../data/styles/line_simpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
+import ol_point_icon from '../data/olStyles/point_icon';
 import ol_line_simpleline from '../data/olStyles/line_simpleline';
 import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
-import { CircleSymbolizer, LineSymbolizer, FillSymbolizer, TextSymbolizer, Style } from 'geostyler-style';
+import {
+  CircleSymbolizer,
+  LineSymbolizer,
+  FillSymbolizer,
+  TextSymbolizer,
+  Style,
+  IconSymbolizer
+} from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
 
@@ -148,6 +157,24 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olImage).toBeDefined();
           expect(olImage.getRadius()).toEqual(expecSymb.radius);
           expect(olImage.getFill().getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers IconSymbolizer', () => {
+      expect.assertions(6);
+      return styleParser.writeStyle(point_icon)
+        .then((olStyles: ol.style.Style[]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_icon.rules[0].symbolizer as IconSymbolizer;
+          const olImage: ol.style.Icon = olStyles[0].getImage() as ol.style.Icon;
+
+          expect(olImage.getSrc()).toEqual(expecSymb.image);
+          expect(olImage.getScale()).toEqual(expecSymb.size);
+          // Rotation in openlayers is radians while we use degree
+          expect(olImage.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olImage.getOpacity()).toEqual(expecSymb.opacity);
+
+          expect(olImage).toBeDefined();
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -9,7 +9,8 @@ import {
   FillSymbolizer,
   TextSymbolizer,
   StyleType,
-  PointSymbolizer
+  PointSymbolizer,
+  IconSymbolizer
 } from 'geostyler-style';
 import OlStyleUtil from './Util/OlStyleUtil';
 import { isNumber } from 'util';
@@ -251,10 +252,9 @@ class OlStyleParser implements StyleParser {
       case 'Circle':
         olSymbolizer = this.getOlPointSymbolizerFromCircleSymbolizer(symbolizer);
         break;
-      // case 'Icon':
-      //   // TODO Implement logic for IconSymbolizer parsing
-      //   // sldSymbolizer = this.getSldPointSymbolizerFromIconSymbolizer(symbolizer);
-      //   break;
+      case 'Icon':
+        olSymbolizer = this.getOlIconSymbolizerFromIconSymbolizer(symbolizer);
+        break;
       case 'Text':
         olSymbolizer = this.getOlTextSymbolizerFromTextSymbolizer(symbolizer);
         break;
@@ -311,6 +311,26 @@ class OlStyleParser implements StyleParser {
             OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
         }),
         stroke: stroke
+      })
+    });
+  }
+
+  /**
+   * Get the OL Style object  from an GeoStyler-Style CircleSymbolizer.
+   *
+   * @param {IconSymbolizer} symbolizer  A GeoStyler-Style IconSymbolizer.
+   * @return {object} The OL Style object
+   */
+  getOlIconSymbolizerFromIconSymbolizer(symbolizer: IconSymbolizer) {
+    return new ol.style.Style({
+      image: new ol.style.Icon({
+        src: symbolizer.image,
+        crossOrigin: 'anonymous',
+        offset: symbolizer.offset,
+        opacity: symbolizer.opacity,
+        scale: symbolizer.size || 1,
+        // Rotation in openlayers is radians while we use degree
+        rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
       })
     });
   }

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -316,7 +316,7 @@ class OlStyleParser implements StyleParser {
   }
 
   /**
-   * Get the OL Style object  from an GeoStyler-Style CircleSymbolizer.
+   * Get the OL Style object  from an GeoStyler-Style IconSymbolizer.
    *
    * @param {IconSymbolizer} symbolizer  A GeoStyler-Style IconSymbolizer.
    * @return {object} The OL Style object
@@ -326,7 +326,6 @@ class OlStyleParser implements StyleParser {
       image: new ol.style.Icon({
         src: symbolizer.image,
         crossOrigin: 'anonymous',
-        offset: symbolizer.offset,
         opacity: symbolizer.opacity,
         scale: symbolizer.size || 1,
         // Rotation in openlayers is radians while we use degree


### PR DESCRIPTION
This introduces the `getOlIconSymbolizerFromIconSymbolizer` method to be able to write `ol.style.Icon` from our `IconSymbolizer`.

It also includes the `launch.json` config to debug tests.