### PR TITLE
Set URL for jsdom environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "testRegex": "/src/.*\\.spec.(ts)$",
     "collectCoverageFrom": [
       "src/*.{ts,js}"
-    ]
+    ],
+    "testURL": "http://localhost/"
   }
 }


### PR DESCRIPTION
This PR sets the `testURL` in jest config, otherwise the test suite fails with following error

```
Test suite failed to run

    SecurityError: localStorage is not available for opaque origins
```

See also here https://github.com/facebook/jest/issues/6766#issuecomment-408344243