### PR TITLE
WellKnownNames

### DIFF
--- a/data/olStyles/multi_simplelineLabel.ts
+++ b/data/olStyles/multi_simplelineLabel.ts
@@ -1,6 +1,5 @@
 import OlStyle from 'ol/style/style';
 import OlStyleStroke from 'ol/style/stroke';
-import OlStyleCircle from 'ol/style/circle';
 import OlStyleFill from 'ol/style/fill';
 import OlStyleText from 'ol/style/text';
 

--- a/data/olStyles/point_icon.ts
+++ b/data/olStyles/point_icon.ts
@@ -5,7 +5,7 @@ const olIconPoint = new OlStyle({
   image: new OlStyleIcon({
     src: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
     scale: 0.1,
-    rotation: 0.7853981633974483,
+    rotation: Math.PI / 4,
     opacity: 0.5
   })
 });

--- a/data/olStyles/point_simplecross.ts
+++ b/data/olStyles/point_simplecross.ts
@@ -1,0 +1,16 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import OlStyleFill from 'ol/style/fill';
+
+const olSimpleCross = new OlStyle({
+  image: new OlStyleRegularshape({
+    points: 4,
+    radius: 6,
+    radius2: 0,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    })
+  })
+});
+
+export default olSimpleCross;

--- a/data/olStyles/point_simplesquare.ts
+++ b/data/olStyles/point_simplesquare.ts
@@ -1,0 +1,15 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import OlStyleFill from 'ol/style/fill';
+
+const olSimpleSquare = new OlStyle({
+  image: new OlStyleRegularshape({
+    points: 4,
+    radius: 6,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    })
+  })
+});
+
+export default olSimpleSquare;

--- a/data/olStyles/point_simplestar.ts
+++ b/data/olStyles/point_simplestar.ts
@@ -1,0 +1,16 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import OlStyleFill from 'ol/style/fill';
+
+const olSimpleStar = new OlStyle({
+  image: new OlStyleRegularshape({
+    points: 5,
+    radius: 6,
+    radius2: 2,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    })
+  })
+});
+
+export default olSimpleStar;

--- a/data/olStyles/point_simpletriangle.ts
+++ b/data/olStyles/point_simpletriangle.ts
@@ -1,0 +1,15 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import OlStyleFill from 'ol/style/fill';
+
+const olSimpleTriangle = new OlStyle({
+  image: new OlStyleRegularshape({
+    points: 3,
+    radius: 6,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    })
+  })
+});
+
+export default olSimpleTriangle;

--- a/data/olStyles/point_simplex.ts
+++ b/data/olStyles/point_simplex.ts
@@ -1,0 +1,17 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import OlStyleFill from 'ol/style/fill';
+
+const olSimpleX = new OlStyle({
+  image: new OlStyleRegularshape({
+    points: 4,
+    radius: 6,
+    radius2: 0,
+    angle: Math.PI / 4,
+    fill: new OlStyleFill({
+      color: '#FF0000'
+    })
+  })
+});
+
+export default olSimpleX;

--- a/data/styles/multi_simplefillSimpleline.ts
+++ b/data/styles/multi_simplefillSimpleline.ts
@@ -1,6 +1,6 @@
 import { Style } from 'geostyler-style';
 
-const multi_simplefillSimpleline: Style = {
+const multiSimplefillSimpleline: Style = {
   name: 'OL Style',
   rules: [
     {
@@ -10,7 +10,7 @@ const multi_simplefillSimpleline: Style = {
         color: '#FF0000',
         opacity: undefined,
         outlineColor: undefined
-      },{
+      }, {
         kind: 'Line',
         color: '#FF0000',
         width: 5,
@@ -21,4 +21,4 @@ const multi_simplefillSimpleline: Style = {
   ]
 };
 
-export default multi_simplefillSimpleline;
+export default multiSimplefillSimpleline;

--- a/data/styles/multi_simplelineLabel.ts
+++ b/data/styles/multi_simplelineLabel.ts
@@ -1,6 +1,6 @@
 import { Style } from 'geostyler-style';
 
-const multi_simplelineLabel: Style = {
+const multiSimplelineLabel: Style = {
   name: 'OL Style',
   rules: [
     {
@@ -23,4 +23,4 @@ const multi_simplelineLabel: Style = {
   ]
 };
 
-export default multi_simplelineLabel;
+export default multiSimplelineLabel;

--- a/data/styles/multi_twoRulesSimplepoint.ts
+++ b/data/styles/multi_twoRulesSimplepoint.ts
@@ -1,12 +1,13 @@
 import { Style } from 'geostyler-style';
 
-const multi_twoRulesSimplepoint: Style = {
+const multiTwoRulesSimplepoint: Style = {
   name: 'OL Style',
   rules: [
     {
       name: 'OL Style Rule 0',
       symbolizer: [{
-        kind: 'Circle',
+        kind: 'Mark',
+        wellKnownName: 'Circle',
         color: '#FF0000',
         radius: 6
       }]
@@ -14,7 +15,8 @@ const multi_twoRulesSimplepoint: Style = {
     {
       name: 'OL Style Rule 1',
       symbolizer: [{
-        kind: 'Circle',
+        kind: 'Mark',
+        wellKnownName: 'Circle',
         color: '#FF1111',
         radius: 4
       }]
@@ -22,4 +24,4 @@ const multi_twoRulesSimplepoint: Style = {
   ]
 };
 
-export default multi_twoRulesSimplepoint;
+export default multiTwoRulesSimplepoint;

--- a/data/styles/point_icon.ts
+++ b/data/styles/point_icon.ts
@@ -1,10 +1,10 @@
 import { Style } from 'geostyler-style';
 
 const pointSimplePoint: Style = {
-  name: 'OL Icon Style',
+  name: 'OL Style',
   rules: [
     {
-      name: 'OL Style Rule',
+      name: 'OL Style Rule 0',
       symbolizer: [{
         kind: 'Icon',
         image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',

--- a/data/styles/point_icon.ts
+++ b/data/styles/point_icon.ts
@@ -8,7 +8,7 @@ const pointSimplePoint: Style = {
       symbolizer: [{
         kind: 'Icon',
         image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
-        size: 0.4,
+        size: 0.1,
         opacity: 0.5,
         rotate: 45
       }]

--- a/data/styles/point_simplecross.ts
+++ b/data/styles/point_simplecross.ts
@@ -1,0 +1,22 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleCross: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizer: [{
+        kind: 'Mark',
+        wellKnownName: 'Cross',
+        color: '#FF0000',
+        radius: 6,
+        points: 4,
+        angle: 0,
+        radius2: 0,
+        rotate: 0
+      }]
+    }
+  ]
+};
+
+export default pointSimpleCross;

--- a/data/styles/point_simplepoint.ts
+++ b/data/styles/point_simplepoint.ts
@@ -6,7 +6,8 @@ const pointSimplePoint: Style = {
     {
       name: 'OL Style Rule 0',
       symbolizer: [{
-        kind: 'Circle',
+        kind: 'Mark',
+        wellKnownName: 'Circle',
         color: '#FF0000',
         radius: 6
       }]

--- a/data/styles/point_simplepoint_filter.ts
+++ b/data/styles/point_simplepoint_filter.ts
@@ -16,7 +16,8 @@ const pointSimplePoint: Style = {
         max: 20000
       },
       symbolizer: [{
-        kind: 'Circle',
+        kind: 'Mark',
+        wellKnownName: 'Circle',
         color: '#FF0000',
         radius: 6,
         strokeColor: '#000000',

--- a/data/styles/point_simplesquare.ts
+++ b/data/styles/point_simplesquare.ts
@@ -15,7 +15,7 @@ const pointSimpleSquare: Style = {
         radius: 6,
         points: 4,
         angle: 45,
-        rotation: 0
+        rotate: 0
       }
     }
   ]

--- a/data/styles/point_simplesquare.ts
+++ b/data/styles/point_simplesquare.ts
@@ -3,12 +3,11 @@ import OlStyleRegularshape from 'ol/style/regularshape';
 import { Style } from 'geostyler-style';
 
 const pointSimpleSquare: Style = {
-  type: 'Point',
   name: 'OL Style',
   rules: [
     {
-      name: 'OL Style Rule',
-      symbolizer: {
+      name: 'OL Style Rule 0',
+      symbolizer: [{
         kind: 'Mark',
         wellKnownName: 'Square',
         color: '#FF0000',
@@ -16,7 +15,7 @@ const pointSimpleSquare: Style = {
         points: 4,
         angle: 45,
         rotate: 0
-      }
+      }]
     }
   ]
 };

--- a/data/styles/point_simplesquare.ts
+++ b/data/styles/point_simplesquare.ts
@@ -1,0 +1,24 @@
+import OlStyle from 'ol/style/style';
+import OlStyleRegularshape from 'ol/style/regularshape';
+import { Style } from 'geostyler-style';
+
+const pointSimpleSquare: Style = {
+  type: 'Point',
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule',
+      symbolizer: {
+        kind: 'Mark',
+        wellKnownName: 'Square',
+        color: '#FF0000',
+        radius: 6,
+        points: 4,
+        angle: 45,
+        rotation: 0
+      }
+    }
+  ]
+};
+
+export default pointSimpleSquare;

--- a/data/styles/point_simplestar.ts
+++ b/data/styles/point_simplestar.ts
@@ -1,0 +1,22 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleStar: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizer: [{
+        kind: 'Mark',
+        wellKnownName: 'Star',
+        color: '#FF0000',
+        radius: 6,
+        points: 5,
+        radius2: 2,
+        angle: 0,
+        rotate: 0
+      }]
+    }
+  ]
+};
+
+export default pointSimpleStar;

--- a/data/styles/point_simpletriangle.ts
+++ b/data/styles/point_simpletriangle.ts
@@ -1,0 +1,21 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleTriangle: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizer: [{
+        kind: 'Mark',
+        wellKnownName: 'Triangle',
+        color: '#FF0000',
+        radius: 6,
+        points: 3,
+        angle: 0,
+        rotate: 0
+      }]
+    }
+  ]
+};
+
+export default pointSimpleTriangle;

--- a/data/styles/point_simplex.ts
+++ b/data/styles/point_simplex.ts
@@ -1,0 +1,22 @@
+import { Style } from 'geostyler-style';
+
+const pointSimpleX: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizer: [{
+        kind: 'Mark',
+        wellKnownName: 'X',
+        color: '#FF0000',
+        radius: 6,
+        points: 4,
+        angle: 45,
+        radius2: 0,
+        rotate: 0
+      }]
+    }
+  ]
+};
+
+export default pointSimpleX;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-openlayers-parser#readme",
   "dependencies": {
-    "geostyler-style": "0.9.0",
+    "geostyler-style": "0.10.0",
     "jest-preset-typescript": "1.0.1",
     "ol": "4.6.5"
   },

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -298,7 +298,7 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olSquare.getPoints()).toEqual(expecSymb.points);
           expect(olSquare.getRadius()).toEqual(expecSymb.radius);
           expect(olSquare.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olSquare.getRotation()).toEqual(expecSymb.rotation * Math.PI / 180);
+          expect(olSquare.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
 
           const olSquareFill: OlStyleFill = olSquare.getFill();
           expect(olSquareFill).toBeDefined();

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -3,6 +3,7 @@ import OlStyleText from 'ol/style/text';
 import OlStyleFill from 'ol/style/fill';
 import OlStyleCircle from 'ol/style/circle';
 import OlStyleIcon from 'ol/style/icon';
+import OlStyleRegularshape from 'ol/style/regularshape';
 import OlFeature from 'ol/feature';
 import ol from 'ol';
 type OlStyleFunction = ol.StyleFunction;
@@ -11,13 +12,15 @@ import OlStyleParser from './OlStyleParser';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
 import point_icon from '../data/styles/point_icon';
+import point_simplesquare from '../data/styles/point_simplesquare';
 import line_simpleline from '../data/styles/line_simpleline';
 import multi_twoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import multi_simplefillSimpleline from '../data/styles/multi_simplefillSimpleline';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
-// import ol_point_icon from '../data/olStyles/point_icon';
+import ol_point_icon from '../data/olStyles/point_icon';
+import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
 import ol_line_simpleline from '../data/olStyles/line_simpleline';
 import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
 import ol_multi_twoRulesSimplepoint from '../data/olStyles/multi_twoRulesSimplepoint';
@@ -28,7 +31,8 @@ import {
   FillSymbolizer,
   TextSymbolizer,
   Style,
-  IconSymbolizer
+  IconSymbolizer,
+  SquareSymbolizer
 } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
@@ -55,6 +59,22 @@ describe('OlStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplepoint);
+        });
+    });
+    it('can read a OpenLayers IconSymbolizer', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(ol_point_icon)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_icon);
+        });
+    })
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(ol_point_simplesquare)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplesquare);
         });
     });
     it('can read a OpenLayers LineSymbolizer', () => {
@@ -265,6 +285,26 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olIcon).toBeDefined();
         });
     });
+    it('can write a OpenLayers RegularShape square', () => {
+      expect.assertions(8);
+      return styleParser.writeStyle(point_simplesquare)
+        .then((olStyles: OlStyle[]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_simplesquare.rules[0].symbolizer as SquareSymbolizer;
+          const olSquare: OlStyleRegularshape = olStyles[0].getImage() as OlStyleRegularshape;
+          expect(olSquare).toBeDefined();
+
+          expect(olSquare.getPoints()).toEqual(expecSymb.points);
+          expect(olSquare.getRadius()).toEqual(expecSymb.radius);
+          expect(olSquare.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
+          expect(olSquare.getRotation()).toEqual(expecSymb.rotation * Math.PI / 180);
+
+          const olSquareFill: OlStyleFill = olSquare.getFill();
+          expect(olSquareFill).toBeDefined();
+          expect(olSquareFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
     it('can write a OpenLayers LineSymbolizer', () => {
       expect.assertions(5);
       return styleParser.writeStyle(line_simpleline)
@@ -453,7 +493,7 @@ describe('OlStyleParser implements StyleParser', () => {
 
     describe('#getOlPointSymbolizerFromCircleSymbolizer', () => {
       it('is defined', () => {
-        expect(styleParser.getOlPointSymbolizerFromCircleSymbolizer).toBeDefined();
+        expect(styleParser.getOlPointSymbolizerFromMarkSymbolizer).toBeDefined();
       });
     });
 

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -63,15 +63,15 @@ describe('OlStyleParser implements StyleParser', () => {
     });
     it('can read a OpenLayers IconSymbolizer', () => {
       expect.assertions(2);
-      return styleParser.readStyle(ol_point_icon)
+      return styleParser.readStyle([[ol_point_icon]])
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_icon);
         });
-    })
+    });
     it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', () => {
       expect.assertions(2);
-      return styleParser.readStyle(ol_point_simplesquare)
+      return styleParser.readStyle([[ol_point_simplesquare]])
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplesquare);
@@ -106,7 +106,7 @@ describe('OlStyleParser implements StyleParser', () => {
       return styleParser.readStyle([ol_multi_simplefillSimpleline])
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(multi_simplefillSimpleline)
+          expect(geoStylerStyle).toEqual(multi_simplefillSimpleline);
         });
     });
     // it('can read a OpenLayers TextSymbolizer', () => {
@@ -288,11 +288,11 @@ describe('OlStyleParser implements StyleParser', () => {
     it('can write a OpenLayers RegularShape square', () => {
       expect.assertions(8);
       return styleParser.writeStyle(point_simplesquare)
-        .then((olStyles: OlStyle[]) => {
+        .then((olStyles: OlStyle[][]) => {
           expect(olStyles).toBeDefined();
 
-          const expecSymb = point_simplesquare.rules[0].symbolizer as SquareSymbolizer;
-          const olSquare: OlStyleRegularshape = olStyles[0].getImage() as OlStyleRegularshape;
+          const expecSymb = point_simplesquare.rules[0].symbolizer[0] as SquareSymbolizer;
+          const olSquare: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olSquare).toBeDefined();
 
           expect(olSquare.getPoints()).toEqual(expecSymb.points);

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -13,6 +13,10 @@ import OlStyleParser from './OlStyleParser';
 import point_simplepoint from '../data/styles/point_simplepoint';
 import point_icon from '../data/styles/point_icon';
 import point_simplesquare from '../data/styles/point_simplesquare';
+import point_simplestar from '../data/styles/point_simplestar';
+import point_simpletriangle from '../data/styles/point_simpletriangle';
+import point_simplecross from '../data/styles/point_simplecross';
+import point_simplex from '../data/styles/point_simplex';
 import line_simpleline from '../data/styles/line_simpleline';
 import multi_twoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import multi_simplefillSimpleline from '../data/styles/multi_simplefillSimpleline';
@@ -21,6 +25,10 @@ import point_styledlabel from '../data/styles/point_styledlabel';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
 import ol_point_icon from '../data/olStyles/point_icon';
 import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
+import ol_point_simplestar from '../data/olStyles/point_simplestar';
+import ol_point_simpletriangle from '../data/olStyles/point_simpletriangle';
+import ol_point_simplecross from '../data/olStyles/point_simplecross';
+import ol_point_simplex from '../data/olStyles/point_simplex';
 import ol_line_simpleline from '../data/olStyles/line_simpleline';
 import ol_polygon_transparentpolygon from '../data/olStyles/polygon_transparentpolygon';
 import ol_multi_twoRulesSimplepoint from '../data/olStyles/multi_twoRulesSimplepoint';
@@ -32,10 +40,15 @@ import {
   TextSymbolizer,
   Style,
   IconSymbolizer,
-  SquareSymbolizer
+  SquareSymbolizer,
+  StarSymbolizer,
+  TriangleSymbolizer,
+  CrossSymbolizer,
+  XSymbolizer
 } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
+import olSimpleSquare from '../data/olStyles/point_simplesquare';
 // import { style } from 'openlayers';
 
 it('OlStyleParser is defined', () => {
@@ -75,6 +88,38 @@ describe('OlStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_simplesquare);
+        });
+    });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Star', () => {
+      expect.assertions(2);
+      return styleParser.readStyle([[ol_point_simplestar]])
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplestar);
+        });
+    });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Triangle', () => {
+      expect.assertions(2);
+      return styleParser.readStyle([[ol_point_simpletriangle]])
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simpletriangle);
+        });
+    });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName Cross', () => {
+      expect.assertions(2);
+      return styleParser.readStyle([[ol_point_simplecross]])
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplecross);
+        });
+    });
+    it('can read a OpenLayers MarkSymbolizer as WellKnownName X', () => {
+      expect.assertions(2);
+      return styleParser.readStyle([[ol_point_simplex]])
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_simplex);
         });
     });
     it('can read a OpenLayers LineSymbolizer', () => {
@@ -303,6 +348,89 @@ describe('OlStyleParser implements StyleParser', () => {
           const olSquareFill: OlStyleFill = olSquare.getFill();
           expect(olSquareFill).toBeDefined();
           expect(olSquareFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers RegularShape star', () => {
+      expect.assertions(9);
+      return styleParser.writeStyle(point_simplestar)
+        .then((olStyles: OlStyle[][]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_simplestar.rules[0].symbolizer[0] as StarSymbolizer;
+          const olStar: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
+          expect(olStar).toBeDefined();
+
+          expect(olStar.getPoints()).toEqual(expecSymb.points);
+          expect(olStar.getRadius()).toEqual(expecSymb.radius);
+          expect(olStar.getRadius2()).toEqual(expecSymb.radius2);
+          expect(olStar.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
+          expect(olStar.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+
+          const olStarFill: OlStyleFill = olStar.getFill();
+          expect(olStarFill).toBeDefined();
+          expect(olStarFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers RegularShape triangle', () => {
+      expect.assertions(8);
+      return styleParser.writeStyle(point_simpletriangle)
+        .then((olStyles: OlStyle[][]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_simpletriangle.rules[0].symbolizer[0] as TriangleSymbolizer;
+          const olTriangle: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
+          expect(olTriangle).toBeDefined();
+
+          expect(olTriangle.getPoints()).toEqual(expecSymb.points);
+          expect(olTriangle.getRadius()).toEqual(expecSymb.radius);
+          expect(olTriangle.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
+          expect(olTriangle.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+
+          const olTriangleFill: OlStyleFill = olTriangle.getFill();
+          expect(olTriangleFill).toBeDefined();
+          expect(olTriangleFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers RegularShape cross', () => {
+      expect.assertions(9);
+      return styleParser.writeStyle(point_simplecross)
+        .then((olStyles: OlStyle[][]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_simplecross.rules[0].symbolizer[0] as CrossSymbolizer;
+          const olCross: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
+          expect(olCross).toBeDefined();
+
+          expect(olCross.getPoints()).toEqual(expecSymb.points);
+          expect(olCross.getRadius()).toEqual(expecSymb.radius);
+          expect(olCross.getRadius2()).toEqual(expecSymb.radius2);
+          expect(olCross.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
+          expect(olCross.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+
+          const olCrossFill: OlStyleFill = olCross.getFill();
+          expect(olCrossFill).toBeDefined();
+          expect(olCrossFill.getColor()).toEqual(expecSymb.color);
+        });
+    });
+    it('can write a OpenLayers RegularShape x', () => {
+      expect.assertions(9);
+      return styleParser.writeStyle(point_simplex)
+        .then((olStyles: OlStyle[][]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_simplex.rules[0].symbolizer[0] as XSymbolizer;
+          const olX: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
+          expect(olX).toBeDefined();
+
+          expect(olX.getPoints()).toEqual(expecSymb.points);
+          expect(olX.getRadius()).toEqual(expecSymb.radius);
+          expect(olX.getRadius2()).toEqual(expecSymb.radius2);
+          expect(olX.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
+          expect(olX.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+
+          const olXFill: OlStyleFill = olX.getFill();
+          expect(olXFill).toBeDefined();
+          expect(olXFill.getColor()).toEqual(expecSymb.color);
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -86,8 +86,9 @@ class OlStyleParser implements StyleParser {
         strokeColor: olStrokeStyle ? olStrokeStyle.getColor() as string : undefined,
         strokeOpacity: olStrokeStyle ? OlStyleUtil.getOpacity(olStrokeStyle.getColor() as string) : undefined,
         strokeWidth: olStrokeStyle ? olStrokeStyle.getWidth() : undefined,
+        radius: (radius !== 0) ? radius : 5,
         // Rotation in openlayers is radians while we use degree
-        rotation: olRegularStyle.getRotation() / Math.PI * 180,
+        rotate: olRegularStyle.getRotation() / Math.PI * 180,
         points: points
       } as MarkSymbolizer;
 
@@ -108,7 +109,6 @@ class OlStyleParser implements StyleParser {
               // cross
               const crossSymbolizer: CrossSymbolizer = {
                 wellKnownName: 'Cross',
-                radius1: (radius !== 0) ? radius : 5,
                 radius2: 0,
                 angle: 0
               } as CrossSymbolizer;
@@ -117,7 +117,6 @@ class OlStyleParser implements StyleParser {
               // x
               const xSymbolizer: XSymbolizer = {
                 wellKnownName: 'X',
-                radius1: (radius !== 0) ? radius : 5,
                 radius2: 0,
                 angle: 45
               } as XSymbolizer;
@@ -127,7 +126,6 @@ class OlStyleParser implements StyleParser {
             // square
             const squareSymbolizer: SquareSymbolizer = {
               wellKnownName: 'Square',
-              radius: (radius !== 0) ? radius : 5,
               angle: 45
             } as SquareSymbolizer;
             markSymbolizer = {...baseMarkSymbolizer, ...squareSymbolizer};
@@ -137,7 +135,6 @@ class OlStyleParser implements StyleParser {
           // star
           const starSymbolizer: StarSymbolizer = {
             wellKnownName: 'Star',
-            radius1: isNumber(radius) ? radius : 5,
             radius2: isNumber(radius2) ? radius2 : (5 / 2.5),
             angle: 0
           } as StarSymbolizer;
@@ -447,10 +444,13 @@ class OlStyleParser implements StyleParser {
     let stroke;
     if (markSymbolizer.strokeColor) {
       stroke = new OlStyleStroke({
-        color: markSymbolizer.strokeColor,
-        width: markSymbolizer.strokeWidth
+        color: (markSymbolizer.strokeColor && (markSymbolizer.strokeOpacity !== undefined)) ? 
+        OlStyleUtil.getRgbaColor(markSymbolizer.strokeColor, markSymbolizer.strokeOpacity) : 
+        markSymbolizer.strokeColor,
+        width: markSymbolizer.strokeWidth,
       });
     }
+
     const fill = new OlStyleFill({
       color: (markSymbolizer.color && markSymbolizer.opacity) ?
         OlStyleUtil.getRgbaColor(markSymbolizer.color, markSymbolizer.opacity) : markSymbolizer.color
@@ -459,66 +459,57 @@ class OlStyleParser implements StyleParser {
     let olStyle: OlStyle;
     let shapeOpts: any = {
       fill: fill,
-      stroke: stroke,
-      opacity: markSymbolizer.opacity || 1
+      opacity: markSymbolizer.opacity || 1,
+      radius: markSymbolizer.radius || 5,
+      rotation: markSymbolizer.rotate ? markSymbolizer.rotate * Math.PI / 180 : undefined,
+      stroke: stroke
     };
     
     switch (markSymbolizer.wellKnownName) {
       case 'Circle':
-        shapeOpts.radius = markSymbolizer.radius || 5;
         olStyle = new OlStyle({
           image: new OlStyleCircle(shapeOpts)
         });
         break;
       case 'Square':
         shapeOpts.points = 4;
-        shapeOpts.radius = markSymbolizer.radius || 5;
-        shapeOpts.angle = Math.PI / 4;
+        shapeOpts.angle = 45 * Math.PI / 180;
         // Rotation in openlayers is radians while we use degree
-        shapeOpts.rotation = markSymbolizer.rotation ? markSymbolizer.rotation * Math.PI / 180 : undefined;
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
         });
         break;
       case 'Triangle':
         shapeOpts.points = 3;
-        shapeOpts.radius = markSymbolizer.radius || 5;
         shapeOpts.angle = 0;
         // Rotation in openlayers is radians while we use degree
-        shapeOpts.rotation = markSymbolizer.rotation ? markSymbolizer.rotation * Math.PI / 180 : undefined;
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
         });
         break;
       case 'Star':
         shapeOpts.points = 5;
-        shapeOpts.radius1 = markSymbolizer.radius1 || 5;
-        shapeOpts.radius2 = markSymbolizer.radius2 || (5 / 2.5);
+        shapeOpts.radius2 = markSymbolizer.radius2 || (shapeOpts.radius / 2.5);
         shapeOpts.angle = 0;
         // Rotation in openlayers is radians while we use degree
-        shapeOpts.rotation = markSymbolizer.rotation ? markSymbolizer.rotation * Math.PI / 180 : undefined;
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
         });
         break;
       case 'Cross':
         shapeOpts.points = 4;
-        shapeOpts.radius1 = markSymbolizer.radius1 || 5;
         shapeOpts.radius2 = 0;
         shapeOpts.angle = 0;
         // Rotation in openlayers is radians while we use degree
-        shapeOpts.rotation = markSymbolizer.rotation ? markSymbolizer.rotation * Math.PI / 180 : undefined;
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
         });
         break;
       case 'X':
         shapeOpts.points = 4;
-        shapeOpts.radius1 = markSymbolizer.radius1 || 5;
         shapeOpts.radius2 = 0;
-        shapeOpts.angle = Math.PI / 4;
+        shapeOpts.angle = 45 * Math.PI / 180;
         // Rotation in openlayers is radians while we use degree
-        shapeOpts.rotation = markSymbolizer.rotation ? markSymbolizer.rotation * Math.PI / 180 : undefined;
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
         });

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -442,7 +442,7 @@ class OlStyleParser implements StyleParser {
    */
   getOlPointSymbolizerFromMarkSymbolizer(markSymbolizer: MarkSymbolizer): OlStyle {
     let stroke;
-    if (markSymbolizer.strokeColor) {
+    if (markSymbolizer.strokeColor || markSymbolizer.strokeWidth) {
       stroke = new OlStyleStroke({
         color: (markSymbolizer.strokeColor && (markSymbolizer.strokeOpacity !== undefined)) ? 
         OlStyleUtil.getRgbaColor(markSymbolizer.strokeColor, markSymbolizer.strokeOpacity) : 
@@ -500,6 +500,13 @@ class OlStyleParser implements StyleParser {
         shapeOpts.points = 4;
         shapeOpts.radius2 = 0;
         shapeOpts.angle = 0;
+        // openlayers does not seem to set a default stroke color,
+        // which is needed for regularshapes with radius2 = 0
+        if (shapeOpts.stroke === undefined) {
+          shapeOpts.stroke = new OlStyleStroke({
+            color: '000000'
+          });
+        }
         // Rotation in openlayers is radians while we use degree
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)
@@ -509,6 +516,13 @@ class OlStyleParser implements StyleParser {
         shapeOpts.points = 4;
         shapeOpts.radius2 = 0;
         shapeOpts.angle = 45 * Math.PI / 180;
+        // openlayers does not seem to set a default stroke color,
+        // which is needed for regularshapes with radius2 = 0
+        if (shapeOpts.stroke === undefined) {
+          shapeOpts.stroke = new OlStyleStroke({
+            color: '000000'
+          });
+        }
         // Rotation in openlayers is radians while we use degree
         olStyle = new OlStyle({
           image: new OlStyleRegularshape(shapeOpts)

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -99,7 +99,7 @@ class OlStyleParser implements StyleParser {
             radius: isNumber(radius) ? radius : 5,
             angle: 0
           } as TriangleSymbolizer;
-          markSymbolizer = {...baseMarkSymbolizer, ...triangleSymbolizer}
+          markSymbolizer = {...baseMarkSymbolizer, ...triangleSymbolizer};
           break;
         case 4:
           if (isNumber(radius2)) {
@@ -117,7 +117,7 @@ class OlStyleParser implements StyleParser {
               // x
               const xSymbolizer: XSymbolizer = {
                 wellKnownName: 'X',
-                radius1: (radius !== 0) ? radius: 5,
+                radius1: (radius !== 0) ? radius : 5,
                 radius2: 0,
                 angle: 45
               } as XSymbolizer;

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -442,7 +442,7 @@ class OlStyleParser implements StyleParser {
    */
   getOlPointSymbolizerFromMarkSymbolizer(markSymbolizer: MarkSymbolizer): OlStyle {
     let stroke;
-    if (markSymbolizer.strokeColor || markSymbolizer.strokeWidth) {
+    if (markSymbolizer.strokeColor || markSymbolizer.strokeWidth !== undefined) {
       stroke = new OlStyleStroke({
         color: (markSymbolizer.strokeColor && (markSymbolizer.strokeOpacity !== undefined)) ? 
         OlStyleUtil.getRgbaColor(markSymbolizer.strokeColor, markSymbolizer.strokeOpacity) : 
@@ -452,7 +452,7 @@ class OlStyleParser implements StyleParser {
     }
 
     const fill = new OlStyleFill({
-      color: (markSymbolizer.color && markSymbolizer.opacity) ?
+      color: (markSymbolizer.color && markSymbolizer.opacity !== undefined) ?
         OlStyleUtil.getRgbaColor(markSymbolizer.color, markSymbolizer.opacity) : markSymbolizer.color
     });
 


### PR DESCRIPTION
**Important:** Please wait with merging this PR until

- [x] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/43)
was merged.

Update parser to parse WellKnownNames. geostyler-openlayers-parser now is able to parse WellKnownNames according to definitions in above mentioned PR. 

Added tests and testfiles for every supported WellKnownName. Updated existing tests and testfiles to match new definitions.