### PR TITLE
Parse Halo and Rotation of TextSymbolizer

### DIFF
--- a/data/olStyles/point_styledlabel.ts
+++ b/data/olStyles/point_styledlabel.ts
@@ -12,10 +12,12 @@ const olPointStyledLabel = (feature: ol.Feature, res: number) => {
       color: '#000000'
     }),
     stroke: new OlStyleStroke({
-      color: '#000000'
+      color: '#000000',
+      width: 5
     }),
     offsetX: 0,
-    offsetY: 5
+    offsetY: 5,
+    rotation: Math.PI / 4
   }); 
 };
 

--- a/data/styles/point_styledlabel.ts
+++ b/data/styles/point_styledlabel.ts
@@ -11,7 +11,10 @@ const pointStyledLabel: Style = {
         field: 'name',
         font: ['Arial'],
         size: 12,
-        offset: [0, 5]
+        offset: [0, 5],
+        haloColor: '#000000',
+        haloWidth: 5,
+        rotate: 45
       }]
     }
   ]

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -236,6 +236,7 @@ describe('OlStyleParser implements StyleParser', () => {
         const offsetX = 1909;
         const offsetY = 19.09;
         const font = '19px font-name';
+        const rotation = Math.PI / 4;
 
         const fillOpts: ol.olx.style.FillOptions = {
           color: '#FFFF00'
@@ -245,7 +246,8 @@ describe('OlStyleParser implements StyleParser', () => {
           offsetX,
           offsetY,
           font,
-          fill: new OlStyleFill(fillOpts)
+          fill: new OlStyleFill(fillOpts),
+          rotation
         };
 
         const styleOpts: ol.olx.style.StyleOptions = {
@@ -259,6 +261,7 @@ describe('OlStyleParser implements StyleParser', () => {
         expect(result.size).toBe(19);
         expect(result.font).toEqual([font]);
         expect(result.offset).toEqual([offsetX, offsetY]);
+        expect(result.rotate).toEqual(rotation / Math.PI * 180);
       });
 
       it('generates correct TextSymbolizer for sophisticated fonst styles', () => {
@@ -468,7 +471,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers TextSymbolizer', () => {
-      expect.assertions(11);
+      expect.assertions(13);
       return styleParser.writeStyle(point_styledlabel)
         .then((olStyles: OlStyle[][] | OlStyleFunction[]) => {
           expect(olStyles).toBeDefined();
@@ -488,7 +491,8 @@ describe('OlStyleParser implements StyleParser', () => {
 
           const olTextStroke = olText.getStroke();
           expect(olTextStroke).toBeDefined();
-          expect(olTextStroke.getColor()).toEqual(expecSymb.color);
+          expect(olTextStroke.getColor()).toEqual(expecSymb.haloColor);
+          expect(olTextStroke.getWidth()).toEqual(expecSymb.haloWidth);
 
           const olTextFill = olText.getFill();
           expect(olTextFill).toBeDefined();
@@ -499,6 +503,9 @@ describe('OlStyleParser implements StyleParser', () => {
 
           const olTextContent = olText.getText();
           expect(olTextContent).toEqual(dummyFeat.get('name'));
+
+          const olTextRotation = olText.getRotation();
+          expect(olTextRotation).toEqual(expecSymb.rotate * Math.PI / 180);
 
           const olTextOffsetX = olText.getOffsetX();
           const olTextOffsetY = olText.getOffsetY();

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -258,10 +258,12 @@ describe('OlStyleParser implements StyleParser', () => {
         expect(result).toBeDefined();
         expect(result.kind).toBe('Text');
         expect(result.color).toBe('#FFFF00');
-        expect(result.size).toBe(19);
+        expect(result.size).toBeCloseTo(19);
         expect(result.font).toEqual([font]);
-        expect(result.offset).toEqual([offsetX, offsetY]);
-        expect(result.rotate).toEqual(rotation / Math.PI * 180);
+        expect(result.offset).toHaveLength(2);
+        expect(result.offset[0]).toBeCloseTo(offsetX);
+        expect(result.offset[1]).toBeCloseTo(offsetY);
+        expect(result.rotate).toBeCloseTo(rotation / Math.PI * 180);
       });
 
       it('generates correct TextSymbolizer for sophisticated fonst styles', () => {
@@ -311,7 +313,7 @@ describe('OlStyleParser implements StyleParser', () => {
           const olCircle: OlStyleCircle = olStyles[0][0].getImage() as OlStyleCircle;
 
           expect(olCircle).toBeDefined();
-          expect(olCircle.getRadius()).toEqual(expecSymb.radius);
+          expect(olCircle.getRadius()).toBeCloseTo(expecSymb.radius);
           expect(olCircle.getFill().getColor()).toEqual(expecSymb.color);
         });
     });
@@ -325,10 +327,10 @@ describe('OlStyleParser implements StyleParser', () => {
           const olIcon: OlStyleIcon = olStyles[0][0].getImage() as OlStyleIcon;
 
           expect(olIcon.getSrc()).toEqual(expecSymb.image);
-          expect(olIcon.getScale()).toEqual(expecSymb.size);
+          expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
           // Rotation in openlayers is radians while we use degree
-          expect(olIcon.getRotation()).toEqual(expecSymb.rotate! * Math.PI / 180);
-          expect(olIcon.getOpacity()).toEqual(expecSymb.opacity);
+          expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);
+          expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);
 
           expect(olIcon).toBeDefined();
         });
@@ -343,10 +345,10 @@ describe('OlStyleParser implements StyleParser', () => {
           const olSquare: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olSquare).toBeDefined();
 
-          expect(olSquare.getPoints()).toEqual(expecSymb.points);
-          expect(olSquare.getRadius()).toEqual(expecSymb.radius);
-          expect(olSquare.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olSquare.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olSquare.getPoints()).toBeCloseTo(expecSymb.points);
+          expect(olSquare.getRadius()).toBeCloseTo(expecSymb.radius);
+          expect(olSquare.getAngle()).toBeCloseTo(expecSymb.angle * Math.PI / 180);
+          expect(olSquare.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olSquareFill: OlStyleFill = olSquare.getFill();
           expect(olSquareFill).toBeDefined();
@@ -363,11 +365,11 @@ describe('OlStyleParser implements StyleParser', () => {
           const olStar: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olStar).toBeDefined();
 
-          expect(olStar.getPoints()).toEqual(expecSymb.points);
-          expect(olStar.getRadius()).toEqual(expecSymb.radius);
-          expect(olStar.getRadius2()).toEqual(expecSymb.radius2);
-          expect(olStar.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olStar.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olStar.getPoints()).toBeCloseTo(expecSymb.points);
+          expect(olStar.getRadius()).toBeCloseTo(expecSymb.radius);
+          expect(olStar.getRadius2()).toBeCloseTo(expecSymb.radius2);
+          expect(olStar.getAngle()).toBeCloseTo(expecSymb.angle * Math.PI / 180);
+          expect(olStar.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olStarFill: OlStyleFill = olStar.getFill();
           expect(olStarFill).toBeDefined();
@@ -384,10 +386,10 @@ describe('OlStyleParser implements StyleParser', () => {
           const olTriangle: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olTriangle).toBeDefined();
 
-          expect(olTriangle.getPoints()).toEqual(expecSymb.points);
-          expect(olTriangle.getRadius()).toEqual(expecSymb.radius);
-          expect(olTriangle.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olTriangle.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olTriangle.getPoints()).toBeCloseTo(expecSymb.points);
+          expect(olTriangle.getRadius()).toBeCloseTo(expecSymb.radius);
+          expect(olTriangle.getAngle()).toBeCloseTo(expecSymb.angle * Math.PI / 180);
+          expect(olTriangle.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olTriangleFill: OlStyleFill = olTriangle.getFill();
           expect(olTriangleFill).toBeDefined();
@@ -404,11 +406,11 @@ describe('OlStyleParser implements StyleParser', () => {
           const olCross: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olCross).toBeDefined();
 
-          expect(olCross.getPoints()).toEqual(expecSymb.points);
-          expect(olCross.getRadius()).toEqual(expecSymb.radius);
-          expect(olCross.getRadius2()).toEqual(expecSymb.radius2);
-          expect(olCross.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olCross.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olCross.getPoints()).toBeCloseTo(expecSymb.points);
+          expect(olCross.getRadius()).toBeCloseTo(expecSymb.radius);
+          expect(olCross.getRadius2()).toBeCloseTo(expecSymb.radius2);
+          expect(olCross.getAngle()).toBeCloseTo(expecSymb.angle * Math.PI / 180);
+          expect(olCross.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olCrossFill: OlStyleFill = olCross.getFill();
           expect(olCrossFill).toBeDefined();
@@ -425,11 +427,11 @@ describe('OlStyleParser implements StyleParser', () => {
           const olX: OlStyleRegularshape = olStyles[0][0].getImage() as OlStyleRegularshape;
           expect(olX).toBeDefined();
 
-          expect(olX.getPoints()).toEqual(expecSymb.points);
-          expect(olX.getRadius()).toEqual(expecSymb.radius);
-          expect(olX.getRadius2()).toEqual(expecSymb.radius2);
-          expect(olX.getAngle()).toEqual(expecSymb.angle * Math.PI / 180);
-          expect(olX.getRotation()).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olX.getPoints()).toBeCloseTo(expecSymb.points);
+          expect(olX.getRadius()).toBeCloseTo(expecSymb.radius);
+          expect(olX.getRadius2()).toBeCloseTo(expecSymb.radius2);
+          expect(olX.getAngle()).toBeCloseTo(expecSymb.angle * Math.PI / 180);
+          expect(olX.getRotation()).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olXFill: OlStyleFill = olX.getFill();
           expect(olXFill).toBeDefined();
@@ -447,7 +449,7 @@ describe('OlStyleParser implements StyleParser', () => {
 
           expect(olStroke).toBeDefined();
           expect(olStroke.getColor()).toEqual(expecSymb.color);
-          expect(olStroke.getWidth()).toEqual(expecSymb.width);
+          expect(olStroke.getWidth()).toBeCloseTo(expecSymb.width);
           expect(olStroke.getLineDash()).toEqual(expecSymb.dasharray);
         });
     });
@@ -492,7 +494,7 @@ describe('OlStyleParser implements StyleParser', () => {
           const olTextStroke = olText.getStroke();
           expect(olTextStroke).toBeDefined();
           expect(olTextStroke.getColor()).toEqual(expecSymb.haloColor);
-          expect(olTextStroke.getWidth()).toEqual(expecSymb.haloWidth);
+          expect(olTextStroke.getWidth()).toBeCloseTo(expecSymb.haloWidth);
 
           const olTextFill = olText.getFill();
           expect(olTextFill).toBeDefined();
@@ -505,14 +507,14 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olTextContent).toEqual(dummyFeat.get('name'));
 
           const olTextRotation = olText.getRotation();
-          expect(olTextRotation).toEqual(expecSymb.rotate * Math.PI / 180);
+          expect(olTextRotation).toBeCloseTo(expecSymb.rotate * Math.PI / 180);
 
           const olTextOffsetX = olText.getOffsetX();
           const olTextOffsetY = olText.getOffsetY();
           const expectedOffsetX = expecSymb.offset ? expecSymb.offset[0] : null;
           const expectedOffsetY = expecSymb.offset ? expecSymb.offset[1] : null;
-          expect(olTextOffsetX).toEqual(expectedOffsetX);
-          expect(olTextOffsetY).toEqual(expectedOffsetY);
+          expect(olTextOffsetX).toBeCloseTo(expectedOffsetX);
+          expect(olTextOffsetY).toBeCloseTo(expectedOffsetY);
         });
     });
     it('can write an OpenLayers Style from multiple symbolizers in one Rule', () => {
@@ -533,7 +535,7 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olLine).toBeDefined();
 
           expect(olLine.getColor()).toEqual(expecLine.color);
-          expect(olLine.getWidth()).toEqual(expecLine.width);
+          expect(olLine.getWidth()).toBeCloseTo(expecLine.width);
         });
     });
     it('can write an OpenLayers Style from symbolizers in multiple Rules', () => {
@@ -547,12 +549,12 @@ describe('OlStyleParser implements StyleParser', () => {
           
           const olCircle1 = olStyles[0][0].getImage() as OlStyleCircle;
           expect(olCircle1).toBeDefined();
-          expect(olCircle1.getRadius()).toEqual(expecSymb1.radius);
+          expect(olCircle1.getRadius()).toBeCloseTo(expecSymb1.radius);
           expect(olCircle1.getFill().getColor()).toEqual(expecSymb1.color);
 
           const olCircle2 = olStyles[1][0].getImage() as OlStyleCircle;
           expect(olCircle2).toBeDefined();
-          expect(olCircle2.getRadius()).toEqual(expecSymb2.radius);
+          expect(olCircle2.getRadius()).toBeCloseTo(expecSymb2.radius);
           expect(olCircle2.getFill().getColor()).toEqual(expecSymb2.color);
         });
     });

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -211,9 +211,11 @@ class OlStyleParser implements StyleParser {
   getTextSymbolizerFromOlStyle(olStyle: OlStyle): TextSymbolizer {
     const olTextStyle = olStyle.getText() as OlStyleText;
     const olFillStyle = olTextStyle.getFill() as OlStyleFill;
+    const olStrokeStyle = olTextStyle.getStroke() as OlStyleStroke;
     const offsetX = olTextStyle.getOffsetX();
     const offsetY = olTextStyle.getOffsetY();
     const font = olTextStyle.getFont();
+    const rotation = olTextStyle.getRotation();
 
     // font-size is always the first part of font-size/line-height
     const fontStyleWeightSize: string = font.split('px')[0].trim();
@@ -226,7 +228,10 @@ class OlStyleParser implements StyleParser {
       color: olFillStyle ? OlStyleUtil.getHexColor(olFillStyle.getColor() as string) : undefined,
       size: isFinite(fontSize) ? fontSize : undefined,
       font: [font],
-      offset: offsetX && offsetY ? [offsetX, offsetY] : [0, 0]
+      offset: offsetX && offsetY ? [offsetX, offsetY] : [0, 0],
+      haloColor: olStrokeStyle ? OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,
+      haloWidth: olStrokeStyle ? olStrokeStyle.getWidth() : undefined,
+      rotate: (rotation !== undefined) ? rotation / Math.PI * 180 : undefined
     };
   }
 
@@ -614,11 +619,13 @@ class OlStyleParser implements StyleParser {
             OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
         }),
         stroke: new OlStyleStroke({
-          color: (symbolizer.color && symbolizer.opacity) ?
-            OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
+          color: (symbolizer.haloColor && symbolizer.opacity) ?
+            OlStyleUtil.getRgbaColor(symbolizer.haloColor, symbolizer.opacity) : symbolizer.haloColor,
+          width: symbolizer.haloWidth ? symbolizer.haloWidth : 0
         }),
         offsetX: symbolizer.offset ? symbolizer.offset[0] : 0,
         offsetY: symbolizer.offset ? symbolizer.offset[1] : 0,
+        rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
         // TODO check why props match
         // textAlign: symbolizer.pitchAlignment,
         // textBaseline: symbolizer.anchor


### PR DESCRIPTION
Note that geostyler-style TextSymbolizer halo will be parsed from/to Stroke property of ol.Style.Text.