### PR TITLE
[WIP] Parse format of IconSymbolizer

### DIFF
--- a/data/olStyles/point_iconFormat.ts
+++ b/data/olStyles/point_iconFormat.ts
@@ -1,0 +1,13 @@
+import OlStyle from 'ol/style/style';
+import OlStyleIcon from 'ol/style/icon';
+
+const olIconPoint = new OlStyle({
+  image: new OlStyleIcon({
+    src: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+    scale: 0.1,
+    rotation: Math.PI / 4,
+    opacity: 0.5
+  })
+});
+
+export default olIconPoint;

--- a/data/styles/point_iconFormat.ts
+++ b/data/styles/point_iconFormat.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Icon',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg',
+        format: 'image/svg+xml',
+        size: 0.1,
+        opacity: 0.5,
+        rotate: 45
+      }]
+    }
+  ]
+};
+
+export default pointSimplePoint;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -12,6 +12,7 @@ import OlStyleParser from './OlStyleParser';
 
 import point_simplepoint from '../data/styles/point_simplepoint';
 import point_icon from '../data/styles/point_icon';
+import point_iconFormat from '../data/styles/point_iconFormat';
 import point_simplesquare from '../data/styles/point_simplesquare';
 import point_simplestar from '../data/styles/point_simplestar';
 import point_simpletriangle from '../data/styles/point_simpletriangle';
@@ -24,6 +25,7 @@ import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygo
 import point_styledlabel from '../data/styles/point_styledlabel';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
 import ol_point_icon from '../data/olStyles/point_icon';
+import ol_point_iconFormat from '../data/olStyles/point_iconFormat';
 import ol_point_simplesquare from '../data/olStyles/point_simplesquare';
 import ol_point_simplestar from '../data/olStyles/point_simplestar';
 import ol_point_simpletriangle from '../data/olStyles/point_simpletriangle';
@@ -80,6 +82,14 @@ describe('OlStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(point_icon);
+        });
+    });
+    it('can read a OpenLayers IconSymbolizer with Format', () => {
+      expect.assertions(2);
+      return styleParser.readStyle([[ol_point_iconFormat]])
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_iconFormat);
         });
     });
     it('can read a OpenLayers MarkSymbolizer as WellKnownName Square', () => {
@@ -327,6 +337,25 @@ describe('OlStyleParser implements StyleParser', () => {
           const olIcon: OlStyleIcon = olStyles[0][0].getImage() as OlStyleIcon;
 
           expect(olIcon.getSrc()).toEqual(expecSymb.image);
+          expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
+          // Rotation in openlayers is radians while we use degree
+          expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);
+          expect(olIcon.getOpacity()).toBeCloseTo(expecSymb.opacity);
+
+          expect(olIcon).toBeDefined();
+        });
+    });
+    it('can write a OpenLayers IconSymbolizer with Format', () => {
+      expect.assertions(7);
+      return styleParser.writeStyle(point_iconFormat)
+        .then((olStyles: OlStyle[][]) => {
+          expect(olStyles).toBeDefined();
+
+          const expecSymb = point_iconFormat.rules[0].symbolizers[0] as IconSymbolizer;
+          const olIcon: OlStyleIcon = olStyles[0][0].getImage() as OlStyleIcon;
+
+          expect(olIcon.getSrc()).toEqual(expecSymb.image);
+          expect(`image/${olIcon.getSrc().split('.').pop()}+xml`).toEqual('image/svg+xml');
           expect(olIcon.getScale()).toBeCloseTo(expecSymb.size);
           // Rotation in openlayers is radians while we use degree
           expect(olIcon.getRotation()).toBeCloseTo(expecSymb.rotate! * Math.PI / 180);

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -16,7 +16,8 @@ import {
   CircleSymbolizer,
   SquareSymbolizer,
   CrossSymbolizer,
-  XSymbolizer
+  XSymbolizer,
+  IconMime
 } from 'geostyler-style';
 
 import OlStyle from 'ol/style/style';
@@ -147,9 +148,25 @@ class OlStyleParser implements StyleParser {
     } else {
       // icon
       const olIconStyle: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
+      const imgSrc: string = olIconStyle.getSrc();
+      const imgExt = imgSrc.split('.').pop();
+      let format: IconMime | undefined;
+      switch (imgExt) {
+        case 'png':
+        case 'jpeg':
+        case 'gif':
+          format = `image/${imgExt}` as IconMime;
+          break;
+        case 'svg':
+          format = 'image/svg+xml';
+          break;
+        default:
+          break;
+      }
       let iconSymbolizer: IconSymbolizer = {
         kind: 'Icon',
-        image: olIconStyle.getSrc() ? olIconStyle.getSrc() : undefined,
+        image: imgSrc ? imgSrc : undefined,
+        format: format ? format : undefined,
         opacity: olIconStyle.getOpacity(),
         size: (olIconStyle.getScale() !== 0) ? olIconStyle.getScale() : 5,
         // Rotation in openlayers is radians while we use degree


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [ ] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/49)
was merged.

With this PR, `format` property of IconSymbolizer will be parsed. Updated tests and testfiles accordingly.

Supported mime-types are:
`image/png` `image/jpeg` `image/gif` `image/svg+xml`