### PR TITLE
Parse TextSymbolizer template

### DIFF
--- a/data/olStyles/point_styledLabel_static.ts
+++ b/data/olStyles/point_styledLabel_static.ts
@@ -5,9 +5,7 @@ import OlStyle from 'ol/style/style';
 
 const olPointStyledLabel = new OlStyle({
   text: new OlStyleText({
-    // textAlign: align == '' ? undefined : align,
-    // textBaseline: baseline,
-    text: 'name', // feature.get('name'),
+    text: 'name',
     fill: new OlStyleFill({
       color: '#000000'
     }),

--- a/data/olStyles/point_styledLabel_static.ts
+++ b/data/olStyles/point_styledLabel_static.ts
@@ -1,0 +1,25 @@
+import OlStyleText from 'ol/style/text';
+import OlStyleStroke from 'ol/style/stroke';
+import OlStyleFill from 'ol/style/fill';
+import OlStyle from 'ol/style/style';
+
+const olPointStyledLabel = new OlStyle({
+  text: new OlStyleText({
+    // textAlign: align == '' ? undefined : align,
+    // textBaseline: baseline,
+    text: 'name', // feature.get('name'),
+    fill: new OlStyleFill({
+      color: '#000000'
+    }),
+    stroke: new OlStyleStroke({
+      color: '#000000',
+      width: 5
+    }),
+    offsetX: 0,
+    offsetY: 5,
+    rotation: Math.PI / 4,
+    font: '12px Arial'
+  })
+});
+
+export default olPointStyledLabel;

--- a/data/styles/multi_simplelineLabel.ts
+++ b/data/styles/multi_simplelineLabel.ts
@@ -14,7 +14,7 @@ const multiSimplelineLabel: Style = {
       {
         kind: 'Text',
         color: '#000000',
-        field: 'name',
+        label: '{{name}}',
         font: ['Arial'],
         size: 12,
         offset: [0, 5]

--- a/data/styles/point_styledLabel_static.ts
+++ b/data/styles/point_styledLabel_static.ts
@@ -4,11 +4,11 @@ const pointStyledLabel: Style = {
   name: 'OL Style',
   rules: [
     {
-      name: 'OL Style Rule',
+      name: 'OL Style Rule 0',
       symbolizers: [{
         kind: 'Text',
         color: '#000000',
-        label: '{{name}}',
+        label: 'name',
         font: ['Arial'],
         size: 12,
         offset: [0, 5],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-openlayers-parser#readme",
   "dependencies": {
-    "geostyler-style": "0.13.0",
+    "geostyler-style": "0.14.0",
     "jest-preset-typescript": "1.0.1",
     "ol": "4.6.5"
   },

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -239,7 +239,8 @@ class OlStyleParser implements StyleParser {
       size: isFinite(fontSize) ? fontSize : undefined,
       font: fontFamily,
       offset: (offsetX !== undefined) && (offsetY !== undefined) ? [offsetX, offsetY] : [0, 0],
-      haloColor: olStrokeStyle ? OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,
+      haloColor: olStrokeStyle && olStrokeStyle.getColor() ?
+        OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,
       haloWidth: olStrokeStyle ? olStrokeStyle.getWidth() : undefined,
       rotate: (rotation !== undefined) ? rotation / Math.PI * 180 : undefined
     };

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -211,19 +211,34 @@ class OlStyleParser implements StyleParser {
     const offsetY = olTextStyle.getOffsetY();
     const font = olTextStyle.getFont();
     const rotation = olTextStyle.getRotation();
+    const text = olTextStyle.getText();
+    let fontStyleWeightSize: string;
+    let fontSizePart: string[];
+    let fontSize: number = Infinity;
+    let fontFamily: string[]|undefined = undefined;
 
-    // font-size is always the first part of font-size/line-height
-    const fontStyleWeightSize: string = font.split('px')[0].trim();
-    const fontSizePart: string[] = fontStyleWeightSize.split(' ');
-    // The last element contains font size
-    const fontSize = parseInt(fontSizePart[fontSizePart.length - 1], 10);
+    if (font) {
+      const fontSplit = font.split('px');
+      // font-size is always the first part of font-size/line-height
+      fontStyleWeightSize = fontSplit[0].trim();
+
+      fontSizePart = fontStyleWeightSize.split(' ');
+      // The last element contains font size
+      fontSize = parseInt(fontSizePart[fontSizePart.length - 1], 10);
+      let fontFamilyPart: string = fontSplit.length === 2 ?
+        fontSplit[1] : fontSplit[2];
+      fontFamily = fontFamilyPart.split(',').map((fn: string) => {
+        return fn.startsWith(' ') ? fn.slice(1) : fn;
+      });
+    }
 
     return {
       kind: 'Text',
+      label: text,
       color: olFillStyle ? OlStyleUtil.getHexColor(olFillStyle.getColor() as string) : undefined,
       size: isFinite(fontSize) ? fontSize : undefined,
-      font: [font],
-      offset: offsetX && offsetY ? [offsetX, offsetY] : [0, 0],
+      font: fontFamily,
+      offset: (offsetX !== undefined) && (offsetY !== undefined) ? [offsetX, offsetY] : [0, 0],
       haloColor: olStrokeStyle ? OlStyleUtil.getHexColor(olStrokeStyle.getColor() as string) : undefined,
       haloWidth: olStrokeStyle ? olStrokeStyle.getWidth() : undefined,
       rotate: (rotation !== undefined) ? rotation / Math.PI * 180 : undefined
@@ -668,37 +683,58 @@ class OlStyleParser implements StyleParser {
    * @param {TextSymbolizer} textSymbolizer A GeoStyler-Style TextSymbolizer.
    * @return {object} The OL StyleFunction
    */
-  getOlTextSymbolizerFromTextSymbolizer(symbolizer: TextSymbolizer): ol.StyleFunction {
-    const olPointStyledLabelFn = (feature: ol.Feature, res: number) => {
-
-      const text = new OlStyleText({
-        font: OlStyleUtil.getTextFont(symbolizer),
-        text: feature.get(symbolizer.field || '') + '',
-        fill: new OlStyleFill({
-          color: (symbolizer.color && symbolizer.opacity) ?
-            OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
-        }),
-        stroke: new OlStyleStroke({
-          color: (symbolizer.haloColor && symbolizer.opacity) ?
-            OlStyleUtil.getRgbaColor(symbolizer.haloColor, symbolizer.opacity) : symbolizer.haloColor,
-          width: symbolizer.haloWidth ? symbolizer.haloWidth : 0
-        }),
-        offsetX: symbolizer.offset ? symbolizer.offset[0] : 0,
-        offsetY: symbolizer.offset ? symbolizer.offset[1] : 0,
-        rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
-        // TODO check why props match
-        // textAlign: symbolizer.pitchAlignment,
-        // textBaseline: symbolizer.anchor
-      });
-
-      const style = new OlStyle({
-        text: text
-      });
-
-      return style;
+  getOlTextSymbolizerFromTextSymbolizer(symbolizer: TextSymbolizer): ol.StyleFunction|OlStyle {
+    const baseProps = {
+      font: OlStyleUtil.getTextFont(symbolizer),
+      fill: new OlStyleFill({
+        color: (symbolizer.color && symbolizer.opacity) ?
+          OlStyleUtil.getRgbaColor(symbolizer.color, symbolizer.opacity) : symbolizer.color
+      }),
+      stroke: new OlStyleStroke({
+        color: (symbolizer.haloColor && symbolizer.opacity) ?
+          OlStyleUtil.getRgbaColor(symbolizer.haloColor, symbolizer.opacity) : symbolizer.haloColor,
+        width: symbolizer.haloWidth ? symbolizer.haloWidth : 0
+      }),
+      offsetX: symbolizer.offset ? symbolizer.offset[0] : 0,
+      offsetY: symbolizer.offset ? symbolizer.offset[1] : 0,
+      rotation: symbolizer.rotate ? symbolizer.rotate * Math.PI / 180 : undefined
+      // TODO check why props match
+      // textAlign: symbolizer.pitchAlignment,
+      // textBaseline: symbolizer.anchor
     };
 
-    return olPointStyledLabelFn;
+    // check if TextSymbolizer.label contains a placeholder
+    const prefix = '\\{\\{';
+    const suffix = '\\}\\}';
+    const regExp = new RegExp(prefix + '.*?' + suffix, 'g');
+    const regExpRes = symbolizer.label ? symbolizer.label.match(regExp) : null;
+    if (regExpRes) {
+      // if it contains a placeholder
+      // return olStyleFunction
+      const olPointStyledLabelFn = (feature: ol.Feature, res: number) => {
+
+        const text = new OlStyleText({
+          text: OlStyleUtil.resolveAttributeTemplate(feature, symbolizer.label as string, ''),
+          ...baseProps
+        });
+
+        const style = new OlStyle({
+          text: text
+        });
+
+        return style;
+      };
+      return olPointStyledLabelFn;
+    } else {
+      // if TextSymbolizer does not contain a placeholder
+      // return OlStyle
+      return new OlStyle({
+        text: new OlStyleText({
+          text: symbolizer.label,
+          ...baseProps
+        })
+      });
+    }
   }
 
 }

--- a/src/Util/OlStyleUtil.spec.ts
+++ b/src/Util/OlStyleUtil.spec.ts
@@ -1,4 +1,6 @@
 import OlStyleUtil from './OlStyleUtil';
+import OlFeature from 'ol/feature';
+import OlGeomPoint from 'ol/geom/point';
 import { TextSymbolizer } from 'geostyler-style';
 
 describe('OlStyleUtil', () => {
@@ -72,13 +74,98 @@ describe('OlStyleUtil', () => {
       const symb: TextSymbolizer = {
         kind: 'Text',
         color: '#000000',
-        field: 'name',
+        label: 'name',
         font: ['Arial'],
         size: 12,
         offset: [0, 5]
       };
       const opac = OlStyleUtil.getTextFont(symb);
       expect(opac).toEqual('Normal 12px Arial');
+    });
+  });
+
+  describe('#resolveAttributeTemplate', () => {
+    let coords: [number, number];
+    let geom;
+    let props: any;
+    let feat: OlFeature;
+    let featId;
+
+    beforeEach(() => {
+      featId = 'BVB.BORUSSIA';
+      coords = [1909, 1909];
+      geom = new OlGeomPoint(coords);
+      props = {
+        name: 'Shinji Kagawa',
+        address: 'Borsigplatz 9',
+        city: 'Dortmund',
+        homepage: 'https://www.bvb.de/',
+        'exists-and-is-undefined': undefined,
+        'exists-and-is-null': null
+      };
+      feat = new OlFeature({
+        geometry: geom
+      });
+
+      feat.setProperties(props);
+      feat.setId(featId);
+    });
+    it('resolves the given template string with the feature attributes', () => {
+      let template = '{{name}}';
+      let got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe(props.name);
+
+      // It's case insensitive.
+      template = '{{NAmE}}';
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe(props.name);
+
+      // It resolves static and non-static content.
+      template = 'Contact information: {{name}} {{address}} {{city}}';
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe(`Contact information: ${props.name} ${props.address} ${props.city}`);
+
+      // It doesn't harm the template if not attribute placeholder is given.
+      template = 'No attribute template';
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe(template);
+    });
+
+    it('can be configured wrt handling inexistant / falsy values', () => {
+      let template = '{{exists-and-is-undefined}}|{{exists-and-is-null}}|{{key-does-not-exist}}';
+      let got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe('undefined|null|n.v.');
+      got = OlStyleUtil.resolveAttributeTemplate(
+        feat,
+        template,
+        '',
+        (key: string, val: any) => {return val ? val : ''; }
+      );
+      expect(got).toBe('||');
+      const mockFn = jest.fn(() => {return 'FOO'; });
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template, '', mockFn);
+      expect(mockFn.mock.calls.length).toBe(2);
+      expect(mockFn.mock.calls[0][0]).toBe('exists-and-is-undefined');
+      expect(mockFn.mock.calls[0][1]).toBe(undefined);
+      expect(mockFn.mock.calls[1][0]).toBe('exists-and-is-null');
+      expect(mockFn.mock.calls[1][1]).toBe(null);
+      expect(got).toBe('FOO|FOO|');
+    });
+
+    it('resolves it with a placeholder if attribute could not be found', () => {
+      let template = '{{notAvailable}}';
+      let got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe('n.v.');
+
+      template = '{{name}} {{notAvailable}}';
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template);
+      expect(got).toBe(`${props.name} n.v.`);
+
+      // The placeholder is configurable.
+      let notFoundPlaceHolder = '【ツ】';
+      template = '{{name}} {{notAvailable}}';
+      got = OlStyleUtil.resolveAttributeTemplate(feat, template, notFoundPlaceHolder);
+      expect(got).toBe(`${props.name} ${notFoundPlaceHolder}`);
     });
   });
 

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -100,6 +100,73 @@ class OlStyleUtil {
     const font = symbolizer.font;
     return weight + ' ' + size + 'px ' + font;
   }
+
+  /**
+   * Resolves the given template string with the given feature attributes, e.g.
+   * the template "Size of area is {{AREA_SIZE}} km²" would be to resolved
+   * to "Size of area is 1909 km²" (assuming the feature's attribute AREA_SIZE
+   * really exists).
+   *
+   * @param {ol.Feature} feature The feature to get the attributes from.
+   * @param {String} template The template string to resolve.
+   * @param {String} [noValueFoundText] The text to apply, if the templated value
+   *   could not be found, default is to 'n.v.'.
+   * @param {Function} [valueAdjust] A method that will be called with each
+   *   key/value match, we'll use what this function returns for the actual
+   *   replacement. Optional, defaults to a function which will return the raw
+   *   value it received. This can be used for last minute adjustments before
+   *   replacing happens, e.g. to filter out falsy values or to do number
+   *   formatting and such.
+   * @return {String} The resolved template string.
+   */
+  static resolveAttributeTemplate(
+    feature: ol.Feature,
+    template: string,
+    noValueFoundText: string = 'n.v.',
+    valueAdjust: Function = (key: string, val: any) => val
+    ) {
+
+    let attributeTemplatePrefix = '\\{\\{';
+    let attributeTemplateSuffix = '\\}\\}';
+
+    // Find any character between two braces (including the braces in the result)
+    let regExp = new RegExp(attributeTemplatePrefix + '(.*?)' + attributeTemplateSuffix, 'g');
+    let regExpRes = template.match(regExp);
+
+    // If we have a regex result, it means we found a placeholder in the
+    // template and have to replace the placeholder with its appropriate value.
+    if (regExpRes) {
+      // Iterate over all regex match results and find the proper attribute
+      // for the given placeholder, finally set the desired value to the hover.
+      // field text
+      regExpRes.forEach((res) => {
+        // We count every non matching candidate. If this count is equal to
+        // the objects length, we assume that there is no match at all and
+        // set the output value to the value of "noValueFoundText".
+        let noMatchCnt = 0;
+
+        for (let [key, value] of Object.entries(feature.getProperties())) {
+          // Remove the suffixes and find the matching attribute column.
+          let attributeName = res.slice(2, res.length - 2);
+
+          if (attributeName.toLowerCase() === key.toLowerCase()) {
+            template = template.replace(res, valueAdjust(key, value));
+            break;
+          } else {
+            noMatchCnt++;
+          }
+        }
+
+        // No key match found for this feature (e.g. if key not
+        // present or value is null).
+        if (noMatchCnt === Object.keys(feature.getProperties()).length) {
+          template = template.replace(res, noValueFoundText);
+        }
+      });
+    }
+
+    return template;
+  }
 }
 
 export default OlStyleUtil;

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -139,7 +139,7 @@ class OlStyleUtil {
       // Iterate over all regex match results and find the proper attribute
       // for the given placeholder, finally set the desired value to the hover.
       // field text
-      regExpRes.forEach((res) => {
+      regExpRes.forEach(res => {
         // We count every non matching candidate. If this count is equal to
         // the objects length, we assume that there is no match at all and
         // set the output value to the value of "noValueFoundText".


### PR DESCRIPTION
**Important:** Please wait with merging this PR until
- [x] [this PR from geostyler-style](https://github.com/terrestris/geostyler-style/pull/59)
was merged.

With this PR it is possible to parse templates for TextSymbolizers. Simple text will be parsed as static text. Text in double curly braces ({{}}) will be interpreted as feature property. Combinations are possible.

If a template only contains simple text, an OpenLayers StyleText will be returned instead of an OlStyleFunction. This allows bidirectional parsing of those. If a template contains at least one set of double curly braces, an OlStyleFunction will be returned.

Also fixed parsing of fonts in TextSymbolizer.

Tests and testfiles were added/updated accordingly.