### PR TITLE
Create browser-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /build
+/browser
 
 # misc
 .DS_Store

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -1,0 +1,26 @@
+const webpack = require("webpack");
+module.exports = {
+  entry: "./src/OlStyleParser.ts",
+  output: {
+    filename: "olStyleParser.js",
+    path: __dirname + "/browser",
+    library: "OlStyleParser"
+  },
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".ts", ".tsx", ".js", ".json"]
+  },
+  module: {
+    rules: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+      {
+        test: /\.ts$/,
+        include: /src/,
+        loader: "awesome-typescript-loader"
+      },
+    ]
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin(),
+  ]
+};

--- a/browser-build.config.js
+++ b/browser-build.config.js
@@ -4,7 +4,7 @@ module.exports = {
   output: {
     filename: "olStyleParser.js",
     path: __dirname + "/browser",
-    library: "OlStyleParser"
+    library: "GeoStylerOpenlayersParser"
   },
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "build/dist/OlStyleParser.js",
   "files": [
     "build",
-    "index.d.ts"
+    "index.d.ts",
+    "browser"
   ],
   "repository": {
     "type": "git",
@@ -29,7 +30,8 @@
     "ol": "4.6.5"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && npm run build:browser",
+    "build:browser": "webpack --config browser-build.config.js",
     "prebuild": "npm run test",
     "pretest": "npm run lint",
     "prepublishOnly": "npm run build",
@@ -41,6 +43,7 @@
     "@types/jest": "23.1.0",
     "@types/node": "10.3.3",
     "@types/ol": "4.6.2",
+    "awesome-typescript-loader": "4.0.1",
     "babel-core": "6.26.3",
     "babel-jest": "23.4.0",
     "babel-preset-env": "1.7.0",
@@ -50,7 +53,9 @@
     "np": "3.0.4",
     "ts-jest": "22.4.6",
     "tslint": "5.10.0",
-    "typescript": "2.9.2"
+    "typescript": "2.9.2",
+    "webpack": "3.12.0",
+    "webpack-cli": "3.1.2"
   },
   "jest": {
     "testURL": "http://localhost/",

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -31,7 +31,7 @@ import { isNumber } from 'util';
  * @class OlStyleParser
  * @implements StyleParser
  */
-class OlStyleParser implements StyleParser {
+export class OlStyleParser implements StyleParser {
 
   /**
    * The name of the OlStyleParser.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -29,6 +29,8 @@
     "jest",
     "data",
     "**/*.spec.ts",
-    "coverage"
+    "coverage",
+    "browser-build.config.js",
+    "browser"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,9 @@
     "jest",
     "src/setupTests.ts",
     "src/**.spec.ts",
-    "data"
+    "data",
+    "coverage",
+    "browser",
+    "browser-build.config.js"
   ]
 }


### PR DESCRIPTION
This PR creates a browser build for the geostyler-openlayers-parser. Build is located in `/browser` and contains a single file `olStyleParser.js`.

In the browser geostyler-openlayers-parser can be included via
```html
<script src="node_modules/geostyler-openlayers-parser/browser/olStyleParser.js"></script>
```
and used via
```js
var olParser = new GeoStylerOpenlayersParser.OlStyleParser();
olParser.writeStyle(...)
  .then(...);
...
```