### PR TITLE
Update geostyler-style & fix browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-openlayers-parser#readme",
   "dependencies": {
-    "geostyler-style": "0.14.0",
+    "geostyler-style": "0.14.1",
     "jest-preset-typescript": "1.2.0",
     "ol": "4.6.5"
   },
@@ -41,10 +41,10 @@
   },
   "devDependencies": {
     "@babel/polyfill": "7.0.0",
-    "@types/jest": "23.3.5",
-    "@types/node": "10.11.6",
+    "@types/jest": "23.3.6",
+    "@types/node": "10.12.0",
     "@types/ol": "4.6.2",
-    "awesome-typescript-loader": "5.2.1",
+    "awesome-typescript-loader": "4.0.1",
     "babel-core": "6.26.3",
     "babel-jest": "23.6.0",
     "babel-preset-env": "1.7.0",
@@ -55,7 +55,7 @@
     "ts-jest": "22.4.6",
     "tslint": "5.11.0",
     "typescript": "3.1.2",
-    "webpack": "4.21.0",
+    "webpack": "3.12.0",
     "webpack-cli": "3.1.2"
   },
   "jest": {


### PR DESCRIPTION
Updated geostyler-style version to v0.14.1 and downgraded a few other dependencies to fix the browser build.