### PR TITLE
Parse scale denominator

### DIFF
--- a/data/styles/scaleDenom_line.ts
+++ b/data/styles/scaleDenom_line.ts
@@ -1,0 +1,25 @@
+import { Style } from 'geostyler-style';
+
+const scaleDenomLine: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      scaleDenominator: {
+        min: 0,
+        max: 500
+      },
+      symbolizers: [{
+        kind: 'Line',
+        color: '#000000',
+        width: 3,
+        dasharray: [1, 2, 3, 4],
+        cap: 'round',
+        join: 'miter',
+        dashOffset: 5
+      }]
+    }
+  ]
+};
+
+export default scaleDenomLine;

--- a/data/styles/scaleDenom_line_circle.ts
+++ b/data/styles/scaleDenom_line_circle.ts
@@ -1,0 +1,37 @@
+import { Style } from 'geostyler-style';
+
+const scaleDenomLineCircle: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      scaleDenominator: {
+        min: 0,
+        max: 500
+      },
+      symbolizers: [{
+        kind: 'Line',
+        color: '#000000',
+        width: 3,
+        dasharray: [1, 2, 3, 4],
+        cap: 'round',
+        join: 'miter',
+        dashOffset: 5
+      }]
+    }, {
+      name: 'OL Style Rule 1',
+      scaleDenominator: {
+        min: 500,
+        max: 1000
+      },
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default scaleDenomLineCircle;

--- a/data/styles/scaleDenom_line_circle_overlap.ts
+++ b/data/styles/scaleDenom_line_circle_overlap.ts
@@ -1,0 +1,37 @@
+import { Style } from 'geostyler-style';
+
+const scaleDenomLineCircleOverlap: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      scaleDenominator: {
+        min: 0,
+        max: 800
+      },
+      symbolizers: [{
+        kind: 'Line',
+        color: '#000000',
+        width: 3,
+        dasharray: [1, 2, 3, 4],
+        cap: 'round',
+        join: 'miter',
+        dashOffset: 5
+      }]
+    }, {
+      name: 'OL Style Rule 1',
+      scaleDenominator: {
+        min: 500,
+        max: 1000
+      },
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default scaleDenomLineCircleOverlap;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
 declare module 'geostyler-openlayers-parser';
+declare module '@terrestris/ol-util/dist/MapUtil/MapUtil';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-openlayers-parser#readme",
   "dependencies": {
+    "@terrestris/ol-util": "0.4.0",
     "geostyler-style": "0.14.1",
     "jest-preset-typescript": "1.2.0",
     "lodash": "4.17.11",

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -454,9 +454,7 @@ describe('OlStyleParser implements StyleParser', () => {
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
-          const testFeature = new OlFeature({
-            geometry: new OlGeomPoint([16, 48])
-          });
+          const testFeature = new OlFeature();
           const styles = olStyle(testFeature, 1);
           expect(styles).toHaveLength(1);
           const expecSymb = point_simplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
@@ -473,9 +471,7 @@ describe('OlStyleParser implements StyleParser', () => {
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
-          const testFeature = new OlFeature({
-            geometry: new OlGeomPoint([16, 48])
-          });
+          const testFeature = new OlFeature();
           const styles = olStyle(testFeature, 1);
           expect(styles).toHaveLength(1);
           const expecSymb = point_icon.rules[0].symbolizers[0] as IconSymbolizer;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -5,8 +5,6 @@ import OlStyleCircle from 'ol/style/circle';
 import OlStyleIcon from 'ol/style/icon';
 import OlStyleRegularshape from 'ol/style/regularshape';
 import OlFeature from 'ol/feature';
-import OlGeomPoint from 'ol/geom/point';
-import OlGeomLineString from 'ol/geom/linestring';
 import ol from 'ol';
 
 import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
@@ -31,6 +29,9 @@ import line_simpleline from '../data/styles/line_simpleline';
 import point_styledLabel_static from '../data/styles/point_styledLabel_static';
 import multi_twoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import multi_simplefillSimpleline from '../data/styles/multi_simplefillSimpleline';
+import scaleDenomLine from '../data/styles/scaleDenom_line';
+import scaleDenomLineCircle from '../data/styles/scaleDenom_line_circle';
+import scaleDenomLineCircleOverlap from '../data/styles/scaleDenom_line_circle_overlap';
 import polygon_transparentpolygon from '../data/styles/polygon_transparentpolygon';
 import point_styledlabel from '../data/styles/point_styledlabel';
 import ol_point_simplepoint from '../data/olStyles/point_simplepoint';
@@ -60,7 +61,8 @@ import {
   TextSymbolizer,
   Style,
   IconSymbolizer,
-  MarkSymbolizer
+  MarkSymbolizer,
+  Symbolizer
 } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
@@ -953,6 +955,89 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(typeof olTextContent).toEqual('string');
           expect(olTextContent).toEqual(dummyFeat.get('id') + '');
 
+        });
+    });
+    it('returns style if scale is within scaleDenominators', () => {
+      expect.assertions(3);
+      return styleParser.writeStyle(scaleDenomLine)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const withinScale: number = scaleDenomLine.rules[0].scaleDenominator.min;
+          const beyondScale: number = scaleDenomLine.rules[0].scaleDenominator.max;
+
+          const resolutionRuleOne = OlStyleUtil.getResolutionForScale(withinScale, 'm');
+          const resolutionRuleTwo = OlStyleUtil.getResolutionForScale(beyondScale, 'm');
+
+          const dummyFeat = new OlFeature();
+          const styleWithinScale = olStyle(dummyFeat, resolutionRuleOne);
+          const styleBeyondScale = olStyle(dummyFeat, resolutionRuleTwo);
+
+          expect(styleWithinScale).toHaveLength(1);
+          expect(styleBeyondScale).toHaveLength(0);
+        });
+    });
+    it('returns right style based on scaleDenominators', () => {
+      expect.assertions(11);
+      return styleParser.writeStyle(scaleDenomLineCircle)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const scaleWithinFirst: number = scaleDenomLineCircle.rules[0].scaleDenominator.min;
+          const scaleWithinSecond: number = scaleDenomLineCircle.rules[1].scaleDenominator.min;
+          const scaleBeyond: number = scaleDenomLineCircle.rules[1].scaleDenominator.max;
+
+          const resolutionWithinFirst = OlStyleUtil.getResolutionForScale(scaleWithinFirst, 'm');
+          const resolutionWithinSecond = OlStyleUtil.getResolutionForScale(scaleWithinSecond, 'm');
+          const resolutionBeyond = OlStyleUtil.getResolutionForScale(scaleBeyond, 'm');
+
+          const dummyFeat = new OlFeature();
+          const styleWithinFirst = olStyle(dummyFeat, resolutionWithinFirst);
+          const styleWithinSecond = olStyle(dummyFeat, resolutionWithinSecond);
+          const styleBeyond = olStyle(dummyFeat, resolutionBeyond);
+
+          expect(styleWithinFirst).toHaveLength(1);
+          expect(styleWithinSecond).toHaveLength(1);
+          expect(styleBeyond).toHaveLength(0);
+
+          const styleFirst: OlStyle = styleWithinFirst[0];
+          const expecFirst = scaleDenomLineCircle.rules[0].symbolizers[0] as LineSymbolizer;
+          const olStroke = styleFirst.getStroke();
+          expect(olStroke).toBeDefined();
+          expect(olStroke.getColor()).toEqual(expecFirst.color);
+          expect(olStroke.getWidth()).toBeCloseTo(expecFirst.width);
+          expect(olStroke.getLineDash()).toEqual(expecFirst.dasharray);
+
+          const styleSecond: OlStyle = styleWithinSecond[0];
+          const expecSecond = scaleDenomLineCircle.rules[1].symbolizers[0] as MarkSymbolizer;
+          const olCircle: OlStyleCircle = styleSecond.getImage() as OlStyleCircle;
+          expect(olCircle).toBeDefined();
+          expect(olCircle.getRadius()).toBeCloseTo(expecSecond.radius);
+          expect(olCircle.getFill().getColor()).toEqual(expecSecond.color);
+        });
+    });
+    it('returns styles of all rules that lie within scaleDenominator', () => {
+      expect.assertions(4);
+      return styleParser.writeStyle(scaleDenomLineCircleOverlap)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const scaleOnlyFirst: number = scaleDenomLineCircleOverlap.rules[0].scaleDenominator.min;
+          const scaleOverlap: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.min;
+          const scaleOnlySecond: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.max - 1;
+
+          const resolutionOnlyFirst = OlStyleUtil.getResolutionForScale(scaleOnlyFirst, 'm');
+          const resolutionOverlap = OlStyleUtil.getResolutionForScale(scaleOverlap, 'm');
+          const resolutionOnlySecond = OlStyleUtil.getResolutionForScale(scaleOnlySecond, 'm');
+
+          const dummyFeat = new OlFeature();
+          const styleOnlyFirst = olStyle(dummyFeat, resolutionOnlyFirst);
+          const styleOverlap = olStyle(dummyFeat, resolutionOverlap);
+          const styleOnlySecond = olStyle(dummyFeat, resolutionOnlySecond);
+
+          expect(styleOnlyFirst).toHaveLength(1);
+          expect(styleOverlap).toHaveLength(2);
+          expect(styleOnlySecond).toHaveLength(1);
         });
     });
     // it('can write a OpenLayers style with a filter', () => {

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -5,6 +5,8 @@ import OlStyleCircle from 'ol/style/circle';
 import OlStyleIcon from 'ol/style/icon';
 import OlStyleRegularshape from 'ol/style/regularshape';
 import OlFeature from 'ol/feature';
+import OlGeomPoint from 'ol/geom/point';
+import OlGeomLineString from 'ol/geom/linestring';
 import ol from 'ol';
 
 import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
@@ -447,11 +449,16 @@ describe('OlStyleParser implements StyleParser', () => {
       });
     });
     it('can write a OpenLayers PointSymbolizer', () => {
-      expect.assertions(4);
+      expect.assertions(5);
       return styleParser.writeStyle(point_simplepoint)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
+          const testFeature = new OlFeature({
+            geometry: new OlGeomPoint([16, 48])
+          });
+          const styles = olStyle(testFeature, 1);
+          expect(styles).toHaveLength(1);
           const expecSymb = point_simplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
           const olCircle: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
 
@@ -461,11 +468,16 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers IconSymbolizer', () => {
-      expect.assertions(6);
+      expect.assertions(7);
       return styleParser.writeStyle(point_icon)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
+          const testFeature = new OlFeature({
+            geometry: new OlGeomPoint([16, 48])
+          });
+          const styles = olStyle(testFeature, 1);
+          expect(styles).toHaveLength(1);
           const expecSymb = point_icon.rules[0].symbolizers[0] as IconSymbolizer;
           const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
 
@@ -479,7 +491,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape square', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplesquare)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -499,7 +511,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape star', () => {
-      expect.assertions(9);
+      expect.assertions(10);
       return styleParser.writeStyle(point_simplestar)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -520,7 +532,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape triangle', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simpletriangle)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -540,7 +552,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape cross', () => {
-      expect.assertions(9);
+      expect.assertions(10);
       return styleParser.writeStyle(point_simplecross)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -561,7 +573,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape x', () => {
-      expect.assertions(9);
+      expect.assertions(10);
       return styleParser.writeStyle(point_simplex)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -582,7 +594,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://slash', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simpleslash)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -602,7 +614,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://backslash', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplebackslash)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -622,7 +634,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://vertline', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplevertline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -642,7 +654,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://horline', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplehorline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -662,7 +674,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://carrow', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplecarrow)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -682,7 +694,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://oarrow', () => {
-      expect.assertions(8);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simpleoarrow)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -702,7 +714,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://dot', () => {
-      expect.assertions(4);
+      expect.assertions(5);
       return styleParser.writeStyle(point_simpledot)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -716,7 +728,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://plus', () => {
-      expect.assertions(9);
+      expect.assertions(10);
       return styleParser.writeStyle(point_simpleplus)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -737,7 +749,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://times', () => {
-      expect.assertions(9);
+      expect.assertions(10);
       return styleParser.writeStyle(point_simpletimes)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -758,7 +770,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {
-      expect.assertions(5);
+      expect.assertions(6);
       return styleParser.writeStyle(line_simpleline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -773,7 +785,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers PolygonSymbolizer', () => {
-      expect.assertions(5);
+      expect.assertions(6);
       return styleParser.writeStyle(polygon_transparentpolygon)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -66,6 +66,7 @@ import {
 } from 'geostyler-style';
 
 import OlStyleUtil from './Util/OlStyleUtil';
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 it('OlStyleParser is defined', () => {
   expect(OlStyleParser).toBeDefined();
@@ -966,8 +967,8 @@ describe('OlStyleParser implements StyleParser', () => {
           const withinScale: number = scaleDenomLine.rules[0].scaleDenominator.min;
           const beyondScale: number = scaleDenomLine.rules[0].scaleDenominator.max;
 
-          const resolutionRuleOne = OlStyleUtil.getResolutionForScale(withinScale, 'm');
-          const resolutionRuleTwo = OlStyleUtil.getResolutionForScale(beyondScale, 'm');
+          const resolutionRuleOne = MapUtil.getResolutionForScale(withinScale, 'm');
+          const resolutionRuleTwo = MapUtil.getResolutionForScale(beyondScale, 'm');
 
           const dummyFeat = new OlFeature();
           const styleWithinScale = olStyle(dummyFeat, resolutionRuleOne);
@@ -987,9 +988,9 @@ describe('OlStyleParser implements StyleParser', () => {
           const scaleWithinSecond: number = scaleDenomLineCircle.rules[1].scaleDenominator.min;
           const scaleBeyond: number = scaleDenomLineCircle.rules[1].scaleDenominator.max;
 
-          const resolutionWithinFirst = OlStyleUtil.getResolutionForScale(scaleWithinFirst, 'm');
-          const resolutionWithinSecond = OlStyleUtil.getResolutionForScale(scaleWithinSecond, 'm');
-          const resolutionBeyond = OlStyleUtil.getResolutionForScale(scaleBeyond, 'm');
+          const resolutionWithinFirst = MapUtil.getResolutionForScale(scaleWithinFirst, 'm');
+          const resolutionWithinSecond = MapUtil.getResolutionForScale(scaleWithinSecond, 'm');
+          const resolutionBeyond = MapUtil.getResolutionForScale(scaleBeyond, 'm');
 
           const dummyFeat = new OlFeature();
           const styleWithinFirst = olStyle(dummyFeat, resolutionWithinFirst);
@@ -1026,9 +1027,9 @@ describe('OlStyleParser implements StyleParser', () => {
           const scaleOverlap: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.min;
           const scaleOnlySecond: number = scaleDenomLineCircleOverlap.rules[1].scaleDenominator.max - 1;
 
-          const resolutionOnlyFirst = OlStyleUtil.getResolutionForScale(scaleOnlyFirst, 'm');
-          const resolutionOverlap = OlStyleUtil.getResolutionForScale(scaleOverlap, 'm');
-          const resolutionOnlySecond = OlStyleUtil.getResolutionForScale(scaleOnlySecond, 'm');
+          const resolutionOnlyFirst = MapUtil.getResolutionForScale(scaleOnlyFirst, 'm');
+          const resolutionOverlap = MapUtil.getResolutionForScale(scaleOverlap, 'm');
+          const resolutionOnlySecond = MapUtil.getResolutionForScale(scaleOnlySecond, 'm');
 
           const dummyFeat = new OlFeature();
           const styleOnlyFirst = olStyle(dummyFeat, resolutionOnlyFirst);

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -452,14 +452,11 @@ describe('OlStyleParser implements StyleParser', () => {
       });
     });
     it('can write a OpenLayers PointSymbolizer', () => {
-      expect.assertions(5);
+      expect.assertions(4);
       return styleParser.writeStyle(point_simplepoint)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
-          const testFeature = new OlFeature();
-          const styles = olStyle(testFeature, 1);
-          expect(styles).toHaveLength(1);
           const expecSymb = point_simplepoint.rules[0].symbolizers[0] as MarkSymbolizer;
           const olCircle: OlStyleCircle = olStyle.getImage() as OlStyleCircle;
 
@@ -469,14 +466,11 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers IconSymbolizer', () => {
-      expect.assertions(7);
+      expect.assertions(6);
       return styleParser.writeStyle(point_icon)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
 
-          const testFeature = new OlFeature();
-          const styles = olStyle(testFeature, 1);
-          expect(styles).toHaveLength(1);
           const expecSymb = point_icon.rules[0].symbolizers[0] as IconSymbolizer;
           const olIcon: OlStyleIcon = olStyle.getImage() as OlStyleIcon;
 
@@ -490,7 +484,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape square', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simplesquare)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -510,7 +504,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape star', () => {
-      expect.assertions(10);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplestar)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -531,7 +525,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape triangle', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simpletriangle)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -551,7 +545,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape cross', () => {
-      expect.assertions(10);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplecross)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -572,7 +566,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape x', () => {
-      expect.assertions(10);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simplex)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -593,7 +587,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://slash', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simpleslash)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -613,7 +607,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://backslash', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simplebackslash)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -633,7 +627,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://vertline', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simplevertline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -653,7 +647,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://horline', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simplehorline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -673,7 +667,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://carrow', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simplecarrow)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -693,7 +687,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://oarrow', () => {
-      expect.assertions(9);
+      expect.assertions(8);
       return styleParser.writeStyle(point_simpleoarrow)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -713,7 +707,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://dot', () => {
-      expect.assertions(5);
+      expect.assertions(4);
       return styleParser.writeStyle(point_simpledot)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -727,7 +721,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://plus', () => {
-      expect.assertions(10);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simpleplus)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -748,7 +742,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers RegularShape shape://times', () => {
-      expect.assertions(10);
+      expect.assertions(9);
       return styleParser.writeStyle(point_simpletimes)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -769,7 +763,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers LineSymbolizer', () => {
-      expect.assertions(6);
+      expect.assertions(5);
       return styleParser.writeStyle(line_simpleline)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();
@@ -784,7 +778,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write a OpenLayers PolygonSymbolizer', () => {
-      expect.assertions(6);
+      expect.assertions(5);
       return styleParser.writeStyle(polygon_transparentpolygon)
         .then((olStyle: OlStyle) => {
           expect(olStyle).toBeDefined();

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -511,7 +511,7 @@ export class OlStyleParser implements StyleParser {
     const rules = geoStylerStyle.rules;
     const olStyle: ol.StyleFunction = (feature: ol.Feature, resolution: number): OlStyle[] => {
       // TODO
-      // Filters here
+      // Parse Filters here
       const styles: OlStyle[] = [];
       const scale = MapUtil.getScaleForResolution(resolution, 'm');
       rules.forEach((rule: Rule) => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -21,16 +21,10 @@ import OlStyleCircle from 'ol/style/circle';
 import OlStyleIcon from 'ol/style/icon';
 import OlStyleRegularshape from 'ol/style/regularshape';
 
-const _get = require('lodash/get');
-
 import OlStyleUtil from './Util/OlStyleUtil';
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import { isNumber } from 'util';
 const _get = require('lodash/get');
-
-export type OlParserStyleFct = ol.StyleFunction & {
-  __geoStylerStyle: Style
-};
 
 export type OlParserStyleFct = ol.StyleFunction & {
   __geoStylerStyle: Style

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -450,9 +450,9 @@ export class OlStyleParser implements StyleParser {
     const rules = geoStylerStyle.rules;
     const nrRules = rules.length;
     if (nrRules === 1) {
-      const hasFilter = _get(geoStylerStyle, 'rules[0].filter') !== undefined ? true : false;
-      const hasMinScale = _get(geoStylerStyle, 'rules[0].scaleDenominator.min') !== undefined ? true : false;
-      const hasMaxScale = _get(geoStylerStyle, 'rules[0].scaleDenominator.max') !== undefined ? true : false;
+      const hasFilter = typeof _get(geoStylerStyle, 'rules[0].filter') !== 'undefined' ? true : false;
+      const hasMinScale = typeof _get(geoStylerStyle, 'rules[0].scaleDenominator.min') !== 'undefined' ? true : false;
+      const hasMaxScale = typeof _get(geoStylerStyle, 'rules[0].scaleDenominator.max') !== 'undefined' ? true : false;
       const hasScaleDenominator = hasMinScale || hasMaxScale ? true : false;
       const nrSymbolizers = geoStylerStyle.rules[0].symbolizers.length;
       const hasTextSymbolizer = rules[0].symbolizers.some((symbolizer: Symbolizer) => {
@@ -518,11 +518,11 @@ export class OlStyleParser implements StyleParser {
         const minScale = _get(rule, 'scaleDenominator.min');
         const maxScale = _get(rule, 'scaleDenominator.max');
         let isWithinScale = true;
-        if (minScale !== 'undefined' || maxScale !== 'undefined') {
-          if (minScale !== 'undefined' && scale < minScale) {
+        if (typeof minScale !== 'undefined' || typeof maxScale !== 'undefined') {
+          if (typeof minScale !== 'undefined' && scale < minScale) {
             isWithinScale = false;
           }
-          if (maxScale !== 'undefined' && scale >= maxScale) {
+          if (typeof maxScale !== 'undefined' && scale >= maxScale) {
             isWithinScale = false;
           }
         }

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -29,6 +29,10 @@ export type OlParserStyleFct = ol.StyleFunction & {
   __geoStylerStyle: Style
 };
 
+export type OlParserStyleFct = ol.StyleFunction & {
+  __geoStylerStyle: Style
+};
+
 /**
  * This parser can be used with the GeoStyler.
  * It implements the GeoStyler-Style Parser interface to work with OpenLayers styles.

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -24,6 +24,7 @@ import OlStyleRegularshape from 'ol/style/regularshape';
 const _get = require('lodash/get');
 
 import OlStyleUtil from './Util/OlStyleUtil';
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import { isNumber } from 'util';
 const _get = require('lodash/get');
 
@@ -512,7 +513,7 @@ export class OlStyleParser implements StyleParser {
       // TODO
       // Filters here
       const styles: OlStyle[] = [];
-      const scale = OlStyleUtil.getScaleForResolution(resolution, 'm');
+      const scale = MapUtil.getScaleForResolution(resolution, 'm');
       rules.forEach((rule: Rule) => {
         const minScale = _get(rule, 'scaleDenominator.min');
         const maxScale = _get(rule, 'scaleDenominator.max');

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -1,5 +1,4 @@
 import { TextSymbolizer } from 'geostyler-style';
-import OlProjection from 'ol/proj';
 
 /**
  * Offers some utility functions to work with OpenLayers Styles.
@@ -167,44 +166,6 @@ class OlStyleUtil {
     }
 
     return template;
-  }
-
-  /**
-   * Returns the appropriate scale for the given resolution and units.
-   *
-   * @method
-   * @param {Number} resolution The resolutions to calculate the scale for.
-   * @param {String} units The units the resolution is based on, typically
-   *                       either 'm' or 'degrees'.
-   * @return {Number} The appropriate scale.
-   */
-  static getScaleForResolution (resolution: number, units: string) {
-    var dpi = 25.4 / 0.28;
-    var mpu = OlProjection.METERS_PER_UNIT[units];
-    var inchesPerMeter = 39.37;
-
-    return resolution * mpu * inchesPerMeter * dpi;
-  }
-
-  /**
-   * Calculates the appropriate map resolution for a given scale in the given
-   * units.
-   *
-   * See: https://gis.stackexchange.com/questions/158435/
-   * how-to-get-current-scale-in-openlayers-3
-   *
-   * @method
-   * @param {Number} scale The input scale to calculate the appropriate
-   *                       resolution for.
-   * @param {String} units The units to use for calculation (m or degrees).
-   * @return {Number} The calculated resolution.
-   */
-  static getResolutionForScale (scale: number, units: string) {
-    let dpi = 25.4 / 0.28;
-    let mpu = OlProjection.METERS_PER_UNIT[units];
-    let inchesPerMeter = 39.37;
-
-    return scale / (mpu * inchesPerMeter * dpi);
   }
 }
 

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -185,6 +185,27 @@ class OlStyleUtil {
 
     return resolution * mpu * inchesPerMeter * dpi;
   }
+
+  /**
+   * Calculates the appropriate map resolution for a given scale in the given
+   * units.
+   *
+   * See: https://gis.stackexchange.com/questions/158435/
+   * how-to-get-current-scale-in-openlayers-3
+   *
+   * @method
+   * @param {Number} scale The input scale to calculate the appropriate
+   *                       resolution for.
+   * @param {String} units The units to use for calculation (m or degrees).
+   * @return {Number} The calculated resolution.
+   */
+  static getResolutionForScale (scale: number, units: string) {
+    let dpi = 25.4 / 0.28;
+    let mpu = OlProjection.METERS_PER_UNIT[units];
+    let inchesPerMeter = 39.37;
+
+    return scale / (mpu * inchesPerMeter * dpi);
+  }
 }
 
 export default OlStyleUtil;

--- a/src/Util/OlStyleUtil.ts
+++ b/src/Util/OlStyleUtil.ts
@@ -1,4 +1,5 @@
 import { TextSymbolizer } from 'geostyler-style';
+import OlProjection from 'ol/proj';
 
 /**
  * Offers some utility functions to work with OpenLayers Styles.
@@ -166,6 +167,23 @@ class OlStyleUtil {
     }
 
     return template;
+  }
+
+  /**
+   * Returns the appropriate scale for the given resolution and units.
+   *
+   * @method
+   * @param {Number} resolution The resolutions to calculate the scale for.
+   * @param {String} units The units the resolution is based on, typically
+   *                       either 'm' or 'degrees'.
+   * @return {Number} The appropriate scale.
+   */
+  static getScaleForResolution (resolution: number, units: string) {
+    var dpi = 25.4 / 0.28;
+    var mpu = OlProjection.METERS_PER_UNIT[units];
+    var inchesPerMeter = 39.37;
+
+    return resolution * mpu * inchesPerMeter * dpi;
   }
 }
 


### PR DESCRIPTION
**Important:** This PR builds upon open PR #39. So please wait with merging until the other one was merged.

geostyler-openlayers-parser is now able to parse scaleDenominator in `writeStyle`. OlParserStyleFct checks the current scale and returns only those styles where the current scale lies within specified scaleDenominator(s). 

MinScale is inclusive, MaxScale is exclusive.

resolves https://github.com/terrestris/geostyler/issues/462