### PR TITLE
Replace instanceof with typeof check

### DIFF
--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -529,7 +529,7 @@ export class OlStyleParser implements StyleParser {
           // of OlStyles, not ol.StyleFunctions.
           // So we have to check it and in case of an ol.StyleFunction call that function
           // and add the returned style to const styles.
-            if (olSymbolizer instanceof OlStyle) {
+            if (typeof olSymbolizer !== 'function') {
               styles.push(olSymbolizer);
             } else {
               const styleFromFct: OlStyle = olSymbolizer(feature, resolution) as OlStyle;


### PR DESCRIPTION
instanceof check in `geoStylerStyleToOlParserStyleFct` failes if using another openLayers instance that was passed through constructor. Thus, replacing instanceof with a typeof check to increase robustness. 