### PR TITLE
Write filter & Add jest:watch

### DIFF
--- a/data/styles/filter_invalidFilter.ts
+++ b/data/styles/filter_invalidFilter.ts
@@ -1,0 +1,36 @@
+import { Style } from 'geostyler-style';
+
+const filterInvalidFilter: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      filter: [
+        '&&',
+        'germany',
+        [
+          '||',
+          ['>=', 'population', 100000],
+          '&&'
+        ],
+        []
+      ],
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 10
+      }]
+    }, {
+      name: 'OL Style Rule 1',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default filterInvalidFilter;

--- a/data/styles/filter_nestedFilter.ts
+++ b/data/styles/filter_nestedFilter.ts
@@ -1,0 +1,39 @@
+import { Style } from 'geostyler-style';
+
+const filterNestedFilter: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      filter: [
+        '&&',
+        [
+          '!=',
+          'Name',
+          'Bonn'
+        ],
+        [
+          '>=',
+          'Population',
+          100000
+        ]
+      ],
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 10
+      }]
+    }, {
+      name: 'OL Style Rule 1',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default filterNestedFilter;

--- a/data/styles/filter_nestedFilter.ts
+++ b/data/styles/filter_nestedFilter.ts
@@ -7,15 +7,15 @@ const filterNestedFilter: Style = {
       name: 'OL Style Rule 0',
       filter: [
         '&&',
+        ['==', 'state', 'germany'],
         [
-          '!=',
-          'Name',
-          'Bonn'
+          '||',
+          ['>=', 'population', 100000],
+          ['<', 'population', 200000]
         ],
         [
-          '>=',
-          'Population',
-          100000
+          '!',
+          ['==', 'name', 'Schalke']
         ]
       ],
       symbolizers: [{

--- a/data/styles/filter_simpleFilter.ts
+++ b/data/styles/filter_simpleFilter.ts
@@ -1,0 +1,31 @@
+import { Style } from 'geostyler-style';
+
+const filterSimpleFilter: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      filter: [
+        '==',
+        'Name',
+        'Bonn'
+      ],
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 10
+      }]
+    }, {
+      name: 'OL Style Rule 1',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'Circle',
+        color: '#FF0000',
+        radius: 6
+      }]
+    }
+  ]
+};
+
+export default filterSimpleFilter;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pretest": "npm run lint",
     "prepublishOnly": "npm run build",
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.build.json",
     "release": "np --no-yarn && git push https://github.com/terrestris/geostyler-openlayers-parser.git master --tags"
   },

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -28,6 +28,7 @@ import point_simpletimes from '../data/styles/point_simpletimes';
 import line_simpleline from '../data/styles/line_simpleline';
 import filter_simplefilter from '../data/styles/filter_simpleFilter';
 import filter_nestedfilter from '../data/styles/filter_nestedFilter';
+import filter_invalidfilter from '../data/styles/filter_invalidFilter';
 import point_styledLabel_static from '../data/styles/point_styledLabel_static';
 import multi_twoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import multi_simplefillSimpleline from '../data/styles/multi_simplefillSimpleline';
@@ -1045,7 +1046,7 @@ describe('OlStyleParser implements StyleParser', () => {
 
           const bonnFeat = new OlFeature();
           bonnFeat.set('Name', 'Bonn');
-          const bonnStyle = olStyle(bonnFeat, MapUtil.getResolutionForScale(1, 'm'));
+          const bonnStyle = olStyle(bonnFeat, 1);
           expect(bonnStyle).toBeDefined();
           const bonnRadius = bonnStyle[0].getImage().getRadius();
           const expecBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[0].symbolizers[0] as MarkSymbolizer;
@@ -1053,7 +1054,7 @@ describe('OlStyleParser implements StyleParser', () => {
 
           const notBonnFeat = new OlFeature();
           notBonnFeat.set('Name', 'Koblenz');
-          const notBonnStyle = olStyle(notBonnFeat, MapUtil.getResolutionForScale(1, 'm'));
+          const notBonnStyle = olStyle(notBonnFeat, 1);
           expect(notBonnStyle).toBeDefined();
           const notBonnRadius = notBonnStyle[0].getImage().getRadius();
           const expecNotBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[1].symbolizers[0] as MarkSymbolizer;
@@ -1061,7 +1062,7 @@ describe('OlStyleParser implements StyleParser', () => {
         });
     });
     it('can write an OpenLayers style with a nested filter', () => {
-      expect.assertions(5);
+      expect.assertions(7);
       return styleParser.writeStyle(filter_nestedfilter)
         .then((olStyle: OlParserStyleFct) => {
           expect(olStyle).toBeDefined();
@@ -1070,7 +1071,7 @@ describe('OlStyleParser implements StyleParser', () => {
           matchFilterFeat.set('state', 'germany');
           matchFilterFeat.set('population', 100000);
           matchFilterFeat.set('name', 'Dortmund');
-          const matchStyle = olStyle(matchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
+          const matchStyle = olStyle(matchFilterFeat, 1);
           expect(matchStyle).toBeDefined();
           const matchRadius = matchStyle[0].getImage().getRadius();
           const expecMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[0].symbolizers[0] as MarkSymbolizer;
@@ -1080,10 +1081,37 @@ describe('OlStyleParser implements StyleParser', () => {
           noMatchFilterFeat.set('state', 'germany');
           noMatchFilterFeat.set('population', 100000);
           noMatchFilterFeat.set('name', 'Schalke');
-          const noMatchStyle = olStyle(noMatchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
+          const noMatchStyle = olStyle(noMatchFilterFeat, 1);
           expect(noMatchStyle).toBeDefined();
           const noMatchRadius = noMatchStyle[0].getImage().getRadius();
           const expecNoMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+          expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
+
+          const noMatchFilterFeat2 = new OlFeature();
+          noMatchFilterFeat2.set('state', 'germany');
+          noMatchFilterFeat2.set('population', '100000');
+          noMatchFilterFeat2.set('name', 'Schalke');
+          const noMatchStyle2 = olStyle(noMatchFilterFeat2, 1);
+          expect(noMatchStyle2).toBeDefined();
+          const noMatchRadius2 = noMatchStyle2[0].getImage().getRadius();
+          const expecNoMatch2Symbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+          expect(noMatchRadius2).toBeCloseTo(expecNoMatch2Symbolizer.radius);
+        });
+    });
+    it('does neither match nor crash if filters are invalid', () => {
+      expect.assertions(3);
+      return styleParser.writeStyle(filter_invalidfilter)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const noMatchFilterFeat = new OlFeature();
+          noMatchFilterFeat.set('state', 'germany');
+          noMatchFilterFeat.set('population', 100000);
+          noMatchFilterFeat.set('name', 'Schalke');
+          const noMatchStyle = olStyle(noMatchFilterFeat, 1);
+          expect(noMatchStyle).toBeDefined();
+          const noMatchRadius = noMatchStyle[0].getImage().getRadius();
+          const expecNoMatchSymbolizer: MarkSymbolizer = filter_invalidfilter.rules[1].symbolizers[0] as MarkSymbolizer;
           expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
         });
     });

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -1112,6 +1112,12 @@ describe('OlStyleParser implements StyleParser', () => {
       });
     });
 
+    describe('#geoStylerFilterToOlParserFilter', () => {
+      it('is defined', () => {
+        expect(styleParser.geoStylerFilterToOlParserFilter).toBeDefined();
+      });
+    });
+
     describe('#getOlSymbolizerFromSymbolizer', () => {
       it('is defined', () => {
         expect(styleParser.getOlSymbolizerFromSymbolizer).toBeDefined();

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -1067,8 +1067,9 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(olStyle).toBeDefined();
 
           const matchFilterFeat = new OlFeature();
-          matchFilterFeat.set('Name', 'Koblenz');
-          matchFilterFeat.set('Population', 100000);
+          matchFilterFeat.set('state', 'germany');
+          matchFilterFeat.set('population', 100000);
+          matchFilterFeat.set('name', 'Dortmund');
           const matchStyle = olStyle(matchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
           expect(matchStyle).toBeDefined();
           const matchRadius = matchStyle[0].getImage().getRadius();
@@ -1076,8 +1077,9 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(matchRadius).toBeCloseTo(expecMatchSymbolizer.radius);
 
           const noMatchFilterFeat = new OlFeature();
-          noMatchFilterFeat.set('Name', 'Bonn');
-          noMatchFilterFeat.set('Population', 100000);
+          noMatchFilterFeat.set('state', 'germany');
+          noMatchFilterFeat.set('population', 100000);
+          noMatchFilterFeat.set('name', 'Schalke');
           const noMatchStyle = olStyle(noMatchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
           expect(noMatchStyle).toBeDefined();
           const noMatchRadius = noMatchStyle[0].getImage().getRadius();

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -26,6 +26,8 @@ import point_simpledot from '../data/styles/point_simpledot';
 import point_simpleplus from '../data/styles/point_simpleplus';
 import point_simpletimes from '../data/styles/point_simpletimes';
 import line_simpleline from '../data/styles/line_simpleline';
+import filter_simplefilter from '../data/styles/filter_simpleFilter';
+import filter_nestedfilter from '../data/styles/filter_nestedFilter';
 import point_styledLabel_static from '../data/styles/point_styledLabel_static';
 import multi_twoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
 import multi_simplefillSimpleline from '../data/styles/multi_simplefillSimpleline';
@@ -1035,19 +1037,54 @@ describe('OlStyleParser implements StyleParser', () => {
           expect(styleOnlySecond).toHaveLength(1);
         });
     });
-    // it('can write a OpenLayers style with a filter', () => {
-    //   expect.assertions(2);
-    //   return styleParser.writeStyle(point_simplepoint_filter)
-    //     .then((sldString: string) => {
-    //       expect(sldString).toBeDefined();
-    //       // As string comparison between to XML-Strings is awkward and nonesens
-    //       // we read it again and compare the json input with the parser output
-    //       return styleParser.readStyle(sldString)
-    //         .then(readStyle => {
-    //           expect(readStyle).toEqual(point_simplepoint_filter);
-    //         });
-    //     });
-    // });
+    it('can write an OpenLayers style with a simple filter', () => {
+      expect.assertions(5);
+      return styleParser.writeStyle(filter_simplefilter)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const bonnFeat = new OlFeature();
+          bonnFeat.set('Name', 'Bonn');
+          const bonnStyle = olStyle(bonnFeat, MapUtil.getResolutionForScale(1, 'm'));
+          expect(bonnStyle).toBeDefined();
+          const bonnRadius = bonnStyle[0].getImage().getRadius();
+          const expecBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[0].symbolizers[0] as MarkSymbolizer;
+          expect(bonnRadius).toBeCloseTo(expecBonnSymbolizer.radius);
+
+          const notBonnFeat = new OlFeature();
+          notBonnFeat.set('Name', 'Koblenz');
+          const notBonnStyle = olStyle(notBonnFeat, MapUtil.getResolutionForScale(1, 'm'));
+          expect(notBonnStyle).toBeDefined();
+          const notBonnRadius = notBonnStyle[0].getImage().getRadius();
+          const expecNotBonnSymbolizer: MarkSymbolizer = filter_simplefilter.rules[1].symbolizers[0] as MarkSymbolizer;
+          expect(notBonnRadius).toBeCloseTo(expecNotBonnSymbolizer.radius);
+        });
+    });
+    it('can write an OpenLayers style with a nested filter', () => {
+      expect.assertions(5);
+      return styleParser.writeStyle(filter_nestedfilter)
+        .then((olStyle: OlParserStyleFct) => {
+          expect(olStyle).toBeDefined();
+
+          const matchFilterFeat = new OlFeature();
+          matchFilterFeat.set('Name', 'Koblenz');
+          matchFilterFeat.set('Population', 100000);
+          const matchStyle = olStyle(matchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
+          expect(matchStyle).toBeDefined();
+          const matchRadius = matchStyle[0].getImage().getRadius();
+          const expecMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[0].symbolizers[0] as MarkSymbolizer;
+          expect(matchRadius).toBeCloseTo(expecMatchSymbolizer.radius);
+
+          const noMatchFilterFeat = new OlFeature();
+          noMatchFilterFeat.set('Name', 'Bonn');
+          noMatchFilterFeat.set('Population', 100000);
+          const noMatchStyle = olStyle(noMatchFilterFeat, MapUtil.getResolutionForScale(1, 'm'));
+          expect(noMatchStyle).toBeDefined();
+          const noMatchRadius = noMatchStyle[0].getImage().getRadius();
+          const expecNoMatchSymbolizer: MarkSymbolizer = filter_nestedfilter.rules[1].symbolizers[0] as MarkSymbolizer;
+          expect(noMatchRadius).toBeCloseTo(expecNoMatchSymbolizer.radius);
+        });
+    });
 
     describe('#getOlStyleTypeFromGeoStylerStyle', () => {
       it('is defined', () => {

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -609,8 +609,14 @@ export class OlStyleParser implements StyleParser {
           matchesFilter = prop === filter[2];
           break;
         case '*=':
-          if (typeof filter[2] === 'string') {
-            matchesFilter = prop.includes(filter[2]);
+          // inspired by
+          // https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Polyfill
+          if (typeof filter[2] === 'string' && typeof prop === 'string') {
+            if (filter[2].length > prop.length) {
+              matchesFilter = false;
+            } else {
+              matchesFilter = prop.indexOf(filter[2]) !== -1;
+            }
           }
           break;
         case '!=':

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -577,14 +577,24 @@ export class OlStyleParser implements StyleParser {
     if (isNestedFilter) {
       switch (filter[0]) {
         case '&&':
-          matchesFilter =
-            this.geoStylerFilterToOlParserFilter(feature, filter[1])
-            && this.geoStylerFilterToOlParserFilter(feature, filter[2]);
+          let intermediate = true;
+          let restFilter = filter.slice(1);
+          restFilter.forEach((f: Filter) => {
+            if (!this.geoStylerFilterToOlParserFilter(feature, f)) {
+              intermediate = false;
+            }
+          });
+          matchesFilter = intermediate;
           break;
         case '||':
-          matchesFilter =
-          this.geoStylerFilterToOlParserFilter(feature, filter[1])
-          || this.geoStylerFilterToOlParserFilter(feature, filter[2]);
+          intermediate = false;
+          restFilter = filter.slice(1);
+          restFilter.forEach((f: Filter) => {
+            if (this.geoStylerFilterToOlParserFilter(feature, f)) {
+              intermediate = true;
+            }
+          });
+          matchesFilter = intermediate;
           break;
         case '!':
           matchesFilter = !this.geoStylerFilterToOlParserFilter(feature, filter[1]);


### PR DESCRIPTION
Parser now also writes simple and nested filters. Added tests and jest:watch script to package.json to facilitate testing. 

Closes https://github.com/terrestris/geostyler/issues/461