### PR TITLE
Add dev build excluding openlayers

### DIFF
--- a/dev-build.config.js
+++ b/dev-build.config.js
@@ -1,0 +1,47 @@
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const path = require('path');
+require("@babel/polyfill");
+
+module.exports = {
+  entry: "./src/OlStyleParser.ts",
+  output: {
+    filename: "olStyleParser.js",
+    path: __dirname + "/browser",
+    library: "GeoStylerOpenlayersParser"
+  },
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".ts", ".tsx", ".js", ".json"]
+  },
+  module: {
+    rules: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+      {
+        test: /\.ts$/,
+        include: /src/,
+        loader: "awesome-typescript-loader"
+      },
+    ]
+  },
+  externals: [
+    {
+      'ol/style/style': 'ol.style.Style',
+      'ol/style': 'ol.style',
+      'ol/style/image': 'ol.style.Image',
+      'ol/style/stroke': 'ol.style.Stroke',
+      'ol/style/text': 'ol.style.Text',
+      'ol/style/circle': 'ol.style.Circle',
+      'ol/style/icon': 'ol.style.Icon',
+      'ol/style/regularshape': 'ol.style.RegularShape',
+      'ol/style/fill': 'ol.style.Fill',
+      'ol/map': 'ol.Map',
+      'ol/source/tilewms': 'ol.source.TileWMS',
+      'ol/source/imagewms': 'ol.source.ImageWMS',
+      'ol/layer/group': 'ol.layer.Group',
+      'ol/layer/base': 'ol.layer.Base',
+      'ol/proj': 'ol.proj'
+    }
+  ],
+  plugins: [
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -25,14 +25,17 @@
   },
   "homepage": "https://github.com/terrestris/geostyler-openlayers-parser#readme",
   "dependencies": {
-    "@terrestris/ol-util": "0.4.0",
     "geostyler-style": "0.14.2",
-    "lodash": "4.17.11",
+    "lodash": "4.17.11"
+  },
+  "peerDependencies": {
+    "@terrestris/ol-util": "0.4.0",
     "ol": "4.6.5"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && npm run build:browser",
     "build:browser": "webpack --config browser-build.config.js",
+    "start:dev": "webpack --config dev-build.config.js --watch",
     "prebuild": "npm run test",
     "pretest": "npm run lint",
     "prepublishOnly": "npm run build",

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -78,7 +78,7 @@ export class OlStyleParser implements StyleParser {
    */
   getPointSymbolizerFromOlStyle(olStyle: OlStyle): PointSymbolizer {
     let pointSymbolizer: PointSymbolizer;
-    if (olStyle.getImage() instanceof OlStyleCircle) {
+    if (olStyle.getImage() instanceof this.OlStyleCircleConstructor) {
       // circle
       const olCircleStyle = olStyle.getImage() as OlStyleCircle;
       const olFillStyle = olCircleStyle.getFill();
@@ -94,7 +94,7 @@ export class OlStyleParser implements StyleParser {
         strokeWidth: olStrokeStyle ? olStrokeStyle.getWidth() : undefined
       };
       pointSymbolizer = circleSymbolizer;
-    } else if (olStyle.getImage() instanceof OlStyleRegularshape) {
+    } else if (olStyle.getImage() instanceof this.OlStyleRegularshapeConstructor) {
       // square, triangle, star, cross or x
       const olRegularStyle = olStyle.getImage() as OlStyleRegularshape;
       const olFillStyle = olRegularStyle.getFill();
@@ -128,7 +128,7 @@ export class OlStyleParser implements StyleParser {
             case Math.PI / 4:
               markSymbolizer.wellKnownName = 'shape://slash';
               break;
-            case 2 * Math.PI - (Math.PI / 4): 
+            case 2 * Math.PI - (Math.PI / 4):
               markSymbolizer.wellKnownName = 'shape://backslash';
               break;
             default:
@@ -345,11 +345,11 @@ export class OlStyleParser implements StyleParser {
   getStyleTypeFromOlStyle(olStyle: OlStyle): StyleType {
     let styleType: StyleType;
 
-    if (olStyle.getImage() instanceof OlStyleImage) {
+    if (olStyle.getImage() instanceof this.OlStyleImageConstructor) {
       styleType = 'Point';
-    } else if (olStyle.getText() instanceof OlStyleText) {
+    } else if (olStyle.getText() instanceof this.OlStyleTextConstructor) {
       styleType = 'Point';
-    } else if (olStyle.getFill() instanceof OlStyleFill) {
+    } else if (olStyle.getFill() instanceof this.OlStyleFillConstructor) {
       styleType = 'Fill';
     } else if (olStyle.getStroke() && !olStyle.getFill()) {
       styleType = 'Line';
@@ -604,8 +604,8 @@ export class OlStyleParser implements StyleParser {
     let stroke;
     if (markSymbolizer.strokeColor || markSymbolizer.strokeWidth !== undefined) {
       stroke = new this.OlStyleStrokeConstructor({
-        color: (markSymbolizer.strokeColor && (markSymbolizer.strokeOpacity !== undefined)) ? 
-        OlStyleUtil.getRgbaColor(markSymbolizer.strokeColor, markSymbolizer.strokeOpacity) : 
+        color: (markSymbolizer.strokeColor && (markSymbolizer.strokeOpacity !== undefined)) ?
+        OlStyleUtil.getRgbaColor(markSymbolizer.strokeColor, markSymbolizer.strokeOpacity) :
         markSymbolizer.strokeColor,
         width: markSymbolizer.strokeWidth,
       });
@@ -624,7 +624,7 @@ export class OlStyleParser implements StyleParser {
       rotation: markSymbolizer.rotate ? markSymbolizer.rotate * Math.PI / 180 : undefined,
       stroke: stroke
     };
-    
+
     switch (markSymbolizer.wellKnownName) {
       case 'shape://dot':
       case 'Circle':
@@ -699,7 +699,7 @@ export class OlStyleParser implements StyleParser {
         olStyle = new this.OlStyleConstructor({
           image: new this.OlStyleRegularshapeConstructor(shapeOpts)
         });
-        break; 
+        break;
       case 'shape://horline':
         shapeOpts.points = 2;
         shapeOpts.angle = Math.PI / 2;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -31,6 +31,7 @@
     "**/*.spec.ts",
     "coverage",
     "browser-build.config.js",
+    "dev-build.config.js",
     "browser"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "data",
     "coverage",
     "browser",
-    "browser-build.config.js"
+    "browser-build.config.js",
+    "dev-build.config.js"
   ]
 }


### PR DESCRIPTION
This adds a dev build that excludes OpenLayers. We should discuss if we want this for the prod build as well since we're building a library. See also https://webpack.js.org/guides/author-libraries/

@terrestris/devs Please review.