### PR TITLE
feat(OlFlatStyleParser): support reading icon-width

### DIFF
--- a/data/olFlatStyles/point_icon_simple_size.ts
+++ b/data/olFlatStyles/point_icon_simple_size.ts
@@ -3,7 +3,8 @@ import { FlatStyle } from 'ol/style/flat';
 const pointSimplePoint: FlatStyle = {
   'icon-src': 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
   'icon-rotation': 45,
-  'icon-offset': [10, 20]
+  'icon-offset': [10, 20],
+  'icon-width': 10
 };
 
 export default pointSimplePoint;

--- a/data/styles/point_icon_simple_size.ts
+++ b/data/styles/point_icon_simple_size.ts
@@ -1,0 +1,19 @@
+import { Style } from 'geostyler-style';
+
+const pointSimplePoint: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Icon',
+        image: 'https://avatars1.githubusercontent.com/u/1849416?s=460&v=4',
+        rotate: 45,
+        offset: [10, 20],
+        size: 10
+      }]
+    }
+  ]
+};
+
+export default pointSimplePoint;

--- a/src/OlFlatStyleParser.spec.ts
+++ b/src/OlFlatStyleParser.spec.ts
@@ -5,7 +5,7 @@ import OlFlatStyleParser from './OlFlatStyleParser';
 import polygonSimple from '../data/styles/polygon_simple';
 import lineSimpleLine from '../data/styles/line_simpleline';
 import textPlacementLine from '../data/styles/text_placement_line';
-import pointIconSimple from '../data/styles/point_icon_simple';
+import pointIconSimpleSize from '../data/styles/point_icon_simple_size';
 import pointSimplePoint from '../data/styles/point_simplepoint';
 import pointOpaquePoint from '../data/styles/point_opaquepoint';
 import multiTwoRulesSimplepoint from '../data/styles/multi_twoRulesSimplepoint';
@@ -15,7 +15,7 @@ import filterNestedFilter from '../data/styles/filter_nestedFilter';
 import ol_polygon_simple from '../data/olFlatStyles/polygon_simple';
 import ol_line_simpleline from '../data/olFlatStyles/line_simpleline';
 import ol_text_placement_line from '../data/olFlatStyles/text_placement_line';
-import ol_point_icon_simple from '../data/olFlatStyles/point_icon_simple';
+import ol_point_icon_simple_size from '../data/olFlatStyles/point_icon_simple_size';
 import ol_point_simplepoint from '../data/olFlatStyles/point_simplepoint';
 import ol_point_opaquepoint from '../data/olFlatStyles/point_opaquepoint';
 import ol_multi_twoRulesSimplepoint from '../data/olFlatStyles/multi_twoRulesSimplepoint';
@@ -57,9 +57,9 @@ describe('OlFlatStyleParser implements StyleParser', () => {
     });
 
     it('reads a FlatIcon style', async () => {
-      const { output: geostylerStyle } = await styleParser.readStyle(ol_point_icon_simple);
+      const { output: geostylerStyle } = await styleParser.readStyle(ol_point_icon_simple_size);
       expect(geostylerStyle).toBeDefined();
-      expect(geostylerStyle).toEqual(pointIconSimple);
+      expect(geostylerStyle).toEqual(pointIconSimpleSize);
     });
 
     it('reads a FlatCircle style', async () => {

--- a/src/OlFlatStyleParser.ts
+++ b/src/OlFlatStyleParser.ts
@@ -257,7 +257,9 @@ export class OlFlatStyleParser implements StyleParser<FlatStyleLike> {
         flatStyle['icon-offset']
       ),
       opacity: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['icon-opacity']),
-      rotate: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['icon-rotation'])
+      rotate: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['icon-rotation']),
+      // we use the icon-width here to be consistent with OlStyleParser
+      size: OlFlatStyleUtil.olExpressionToGsExpression<number>(flatStyle['icon-width']),
     };
   }
 


### PR DESCRIPTION
## Description

This adds support for reading icon-width and thus geostyler icon size for ol flat styles.

## Related issues or pull requests

none

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [ x I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
