### PR TITLE
LineSymbolizer GraphicStroke

### DIFF
--- a/data/styles/line_graphicStroke.ts
+++ b/data/styles/line_graphicStroke.ts
@@ -1,0 +1,21 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Line',
+        graphicStroke: {
+          kind: 'Mark',
+          wellKnownName: 'square',
+          color: '#000000',
+          radius: 10
+        }
+      }]
+    }
+  ]
+};
+
+export default lineSimpleLine;

--- a/data/styles/line_graphicStrokeDashArray.ts
+++ b/data/styles/line_graphicStrokeDashArray.ts
@@ -1,0 +1,22 @@
+import { Style } from 'geostyler-style';
+
+const lineSimpleLine: Style = {
+  name: 'OL Style',
+  rules: [
+    {
+      name: 'OL Style Rule 0',
+      symbolizers: [{
+        kind: 'Line',
+        graphicStroke: {
+          kind: 'Mark',
+          wellKnownName: 'square',
+          color: '#000000',
+          radius: 5
+        },
+        dasharray: [20, 10]
+      }]
+    }
+  ]
+};
+
+export default lineSimpleLine;

--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -7,6 +7,8 @@ import OlStyleIcon from 'ol/style/Icon';
 import OlStyleText, { Options as TextOptions } from 'ol/style/Text';
 import OlStyleFill, { Options as FillOptions } from 'ol/style/Fill';
 import OlFeature from 'ol/Feature';
+import OlLineString from 'ol/geom/LineString';
+import OlPoint from 'ol/geom/Point';
 
 import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
 
@@ -31,6 +33,8 @@ import point_simpledot from '../data/styles/point_simpledot';
 import point_simpleplus from '../data/styles/point_simpleplus';
 import point_simpletimes from '../data/styles/point_simpletimes';
 import line_simpleline from '../data/styles/line_simpleline';
+import line_graphicstroke from '../data/styles/line_graphicStroke';
+import line_graphicstroke_dasharray from '../data/styles/line_graphicStrokeDashArray';
 import filter_simplefilter from '../data/styles/filter_simpleFilter';
 import filter_nestedfilter from '../data/styles/filter_nestedFilter';
 import filter_invalidfilter from '../data/styles/filter_invalidFilter';
@@ -855,6 +859,52 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(olStroke?.getColor()).toEqual(expecSymb.color);
     expect(olStroke?.getWidth()).toBeCloseTo(expecSymb.width as number);
     expect(olStroke?.getLineDash()).toEqual(expecSymb.dasharray);
+  });
+  it('can write an OpenLayers LineSymbolizer with graphicStroke', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_graphicstroke);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({
+      geometry: new OlLineString([[0, 0], [0, 20]])
+    });
+    const resolution = 1;
+    const expecSymb = (line_graphicstroke.rules[0].symbolizers[0] as LineSymbolizer).graphicStroke as MarkSymbolizer;
+    const evaluatedStyle = (olStyle as unknown as OlParserStyleFct)(testFeature, resolution)[0];
+    const geometry = evaluatedStyle.getGeometry();
+    expect(geometry).toBeInstanceOf(OlPoint);
+
+    const iconStyle = evaluatedStyle.getImage();
+    const svgString = getDecodedSvg(iconStyle.getSrc() as string);
+    const { wellKnownName, color } = getSvgProperties(svgString) as MarkSymbolizer;
+
+    expect(wellKnownName).toEqual(cleanWellKnownName(expecSymb.wellKnownName));
+    expect(color).toEqual(expecSymb.color);
+  });
+  it('can write an OpenLayers LineSymbolizer with graphicStroke with dash array', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_graphicstroke_dasharray);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({
+      geometry: new OlLineString([[0, 0], [0, 60]])
+    });
+    const resolution = 1;
+    const expecSymb = (line_graphicstroke_dasharray.rules[0].symbolizers[0] as LineSymbolizer).graphicStroke as MarkSymbolizer;
+    const evaluatedStyle = (olStyle as unknown as OlParserStyleFct)(testFeature, resolution);
+    // 4 symbols fit into dash pattern
+    expect(evaluatedStyle).toHaveLength(4);
+
+    const coordsGeom1 = evaluatedStyle[0].getGeometry().getCoordinates();
+    const coordsGeom2 = evaluatedStyle[1].getGeometry().getCoordinates();
+    const coordsGeom3 = evaluatedStyle[2].getGeometry().getCoordinates();
+    const coordsGeom4 = evaluatedStyle[3].getGeometry().getCoordinates();
+
+    // for all geometries the first ordinate is always 0, so we only check the second.
+    expect(coordsGeom1[1]).toBeCloseTo(5);
+    expect(coordsGeom2[1]).toBeCloseTo(15);
+    expect(coordsGeom3[1]).toBeCloseTo(35);
+    expect(coordsGeom4[1]).toBeCloseTo(45);
   });
   it('can write an OpenLayers PolygonSymbolizer', async () => {
     let { output: olStyle } = await styleParser.writeStyle(polygon_transparentpolygon);

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -38,6 +38,8 @@ import OlStyleCircle from 'ol/style/Circle';
 import OlStyleFill from 'ol/style/Fill';
 import OlStyleIcon, { Options as OlStyleIconOptions }  from 'ol/style/Icon';
 import OlStyleRegularshape from 'ol/style/RegularShape';
+import OlLineString from 'ol/geom/LineString';
+import OlMultiLineString from 'ol/geom/MultiLineString';
 import { METERS_PER_UNIT } from 'ol/proj/Units';
 
 import OlStyleUtil, { DEGREES_TO_RADIANS } from './Util/OlStyleUtil';
@@ -53,6 +55,7 @@ import {
   LINE_WELLKNOWNNAMES,
   NOFILL_WELLKNOWNNAMES
 } from './Util/OlSvgUtil';
+import OlGraphicStrokeUtil from './Util/OlGraphicStrokeUtil';
 
 export interface OlParserStyleFct {
   (feature?: any, resolution?: number): any;
@@ -167,6 +170,9 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
   OlStyleCircleConstructor = OlStyleCircle;
   OlStyleIconConstructor = OlStyleIcon;
   OlStyleRegularshapeConstructor = OlStyleRegularshape;
+  OlLineStringContructor = OlLineString;
+  OlMultiLineStringConstructor = OlMultiLineString;
+  OlPointConstructor = OlGeomPoint;
 
   constructor(ol?: any) {
     if (ol) {
@@ -178,6 +184,9 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       this.OlStyleCircleConstructor = ol.style.Circle;
       this.OlStyleIconConstructor = ol.style.Icon;
       this.OlStyleRegularshapeConstructor = ol.style.RegularShape;
+      this.OlLineStringContructor = ol.geom.LineString;
+      this.OlMultiLineStringConstructor = ol.geom.MultiLineString;
+      this.OlPointConstructor = ol.geom.Point;
     }
   }
 
@@ -749,6 +758,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       const hasMaxScale = geoStylerStyle?.rules?.[0]?.scaleDenominator?.max !== undefined ? true : false;
       const hasScaleDenominator = hasMinScale || hasMaxScale ? true : false;
       const hasFunctions = OlStyleUtil.containsGeoStylerFunctions(geoStylerStyle);
+      const hasGraphicStroke = OlGraphicStrokeUtil.containsGraphicStroke(geoStylerStyle);
 
       const nrSymbolizers = geoStylerStyle.rules[0].symbolizers.length;
       const hasTextSymbolizer = rules[0].symbolizers.some((symbolizer: Symbolizer) => {
@@ -757,7 +767,14 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       const hasDynamicIconSymbolizer = rules[0].symbolizers.some((symbolizer: Symbolizer) => {
         return symbolizer.kind === 'Icon' && typeof(symbolizer.image) === 'string' && symbolizer.image.includes('{{');
       });
-      if (!hasFilter && !hasScaleDenominator && !hasTextSymbolizer && !hasDynamicIconSymbolizer && !hasFunctions) {
+      if (
+        !hasFilter
+        && !hasScaleDenominator
+        && !hasTextSymbolizer
+        && !hasDynamicIconSymbolizer
+        && !hasFunctions
+        && !hasGraphicStroke
+      ) {
         if (nrSymbolizers === 1) {
           return this.geoStylerStyleToOlStyle(geoStylerStyle);
         } else {
@@ -858,16 +875,25 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
               }
             }
 
-            const olSymbolizer: any = this.getOlSymbolizerFromSymbolizer(symb, feature);
-            // either an OlStyle or an ol.StyleFunction. OpenLayers only accepts an array
+            const olSymbolizer: any = this.getOlSymbolizerFromSymbolizer(symb, feature, resolution);
+            // either an OlStyle, OlStyle[] or an ol.StyleFunction. OpenLayers only accepts an array
             // of OlStyles, not ol.StyleFunctions.
             // So we have to check it and in case of an ol.StyleFunction call that function
             // and add the returned style to const styles.
-            if (typeof olSymbolizer !== 'function') {
-              styles.push(olSymbolizer);
-            } else {
+            if (typeof olSymbolizer === 'function') {
               const styleFromFct: any = olSymbolizer(feature, resolution);
               styles.push(styleFromFct);
+            } else if (Array.isArray(olSymbolizer)) {
+              olSymbolizer.forEach((s) => {
+                if (typeof s === 'function') {
+                  const styleFromFct: any = s(feature, resolution);
+                  styles.push(styleFromFct);
+                } else {
+                  styles.push(s);
+                }
+              });
+            } else {
+              styles.push(olSymbolizer);
             }
           });
         }
@@ -995,7 +1021,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
    * @param symbolizer A GeoStyler-Style Symbolizer.
    * @return The OpenLayers Style object or a StyleFunction
    */
-  getOlSymbolizerFromSymbolizer(symbolizer: Symbolizer, feature?: OlFeature): OlStyle {
+  getOlSymbolizerFromSymbolizer(symbolizer: Symbolizer, feature?: OlFeature, resolution?: number): OlStyle {
     let olSymbolizer: any;
     symbolizer = structuredClone(symbolizer);
 
@@ -1010,7 +1036,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         olSymbolizer = this.getOlTextSymbolizerFromTextSymbolizer(symbolizer, feature);
         break;
       case 'Line':
-        olSymbolizer = this.getOlLineSymbolizerFromLineSymbolizer(symbolizer, feature);
+        olSymbolizer = this.getOlLineSymbolizerFromLineSymbolizer(symbolizer, feature, resolution);
         break;
       case 'Fill':
         olSymbolizer = this.getOlPolygonSymbolizerFromFillSymbolizer(symbolizer, feature);
@@ -1195,7 +1221,15 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
    * @param symbolizer A GeoStyler-Style LineSymbolizer.
    * @return The OL Style object
    */
-  getOlLineSymbolizerFromLineSymbolizer(symbolizer: LineSymbolizer, feat?: OlFeature): OlStyle | OlStyleStroke {
+  getOlLineSymbolizerFromLineSymbolizer(
+    symbolizer: LineSymbolizer, feat?: OlFeature, resolution?: number
+  ): OlStyle | OlStyleStroke | OlStyle[] {
+    // graphicStroke will always be evaluated in a function, so we
+    // can assume that the feature is available.
+    if (symbolizer.graphicStroke) {
+      // If graphicStroke is set, we ignore unrelated stroke properties
+      return this.getOlGraphicStrokeFromGraphicStroke(symbolizer, feat!, resolution!);
+    }
     for (const key of Object.keys(symbolizer)) {
       if (isGeoStylerFunction(symbolizer[key as keyof LineSymbolizer])) {
         (symbolizer as any)[key] = OlStyleUtil.evaluateFunction((symbolizer as any)[key], feat);
@@ -1216,6 +1250,106 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         lineDashOffset: symbolizer.dashOffset as number
       })
     });
+  }
+
+  getOlGraphicStrokeFromGraphicStroke(
+    symbolizer: LineSymbolizer, feat: OlFeature, resolution: number
+  ) {
+    const geom = feat.getGeometry();
+    if (!geom || !(geom instanceof this.OlLineStringContructor || geom instanceof this.OlMultiLineStringConstructor)) {
+      throw new Error(
+        'GraphicStroke can only be applied to (Multi-)LineString geometries'
+      );
+    }
+
+    const graphicStroke = symbolizer.graphicStroke!;
+    const symbolSize = this.getSymbolSizeFromGraphicStroke(graphicStroke, feat);
+    if (symbolSize <= 0) {
+      console.warn('Symbol size must be greater than zero for graphic stroke. No graphic will be drawn.');
+      return [];
+    }
+    const symbolRotation = graphicStroke.rotate;
+    const evaluatedSymbolRotation = isGeoStylerFunction(symbolRotation)
+      ? OlStyleUtil.evaluateNumberFunction(symbolRotation, feat)
+      : symbolRotation ?? 0;
+    // We currently do not support expressions for dasharrays
+    const dashArray = symbolizer.dasharray as number[] | undefined;
+    const dashOffset = symbolizer.dashOffset || 0;
+    const evaluatedDashOffset = isGeoStylerFunction(dashOffset)
+      ? OlStyleUtil.evaluateNumberFunction(dashOffset, feat)
+      : dashOffset;
+
+    const symbolizerGenerator = (modifiedGraphicStroke: any) => {
+      return this.getOlSymbolizerFromSymbolizer(modifiedGraphicStroke, feat, resolution);
+    };
+
+    if (geom instanceof this.OlLineStringContructor) {
+      return OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        geom,
+        symbolSize,
+        resolution,
+        dashArray,
+        evaluatedDashOffset,
+        evaluatedSymbolRotation,
+        graphicStroke,
+        symbolizerGenerator,
+        this.OlPointConstructor
+      );
+    } else {
+      // For every line in the MultiLineString, we start the pattern at the
+      // beginning of the line. This means that the pattern can be
+      // discontinuous at vertices where the lines connect.
+      return geom.getLineStrings().flatMap(line =>
+        OlGraphicStrokeUtil.processLineStringGraphicStroke(
+          line,
+          symbolSize,
+          resolution,
+          dashArray,
+          evaluatedDashOffset,
+          evaluatedSymbolRotation,
+          graphicStroke,
+          symbolizerGenerator,
+          this.OlPointConstructor
+        )
+      );
+    }
+  }
+
+  /**
+   * Get the size of a symbol from graphicStroke.
+   * @param graphicStroke The graphicStroke from the LineSymbolizer.
+   * @param feat The feature.
+   * @returns The size of the symbol in pixels.
+   */
+  getSymbolSizeFromGraphicStroke(
+    graphicStroke: LineSymbolizer['graphicStroke'], feat: OlFeature
+  ) {
+    let size = 0;
+    if (graphicStroke!.kind === 'Mark') {
+      const radius = graphicStroke!.radius;
+      if (isGeoStylerFunction(radius)) {
+        size = OlStyleUtil.evaluateNumberFunction(radius, feat) * 2;
+      } else {
+        size = (radius ?? 0) * 2;
+      }
+      if (size <= 0) {
+        return size;
+      }
+      const strokeWidth = graphicStroke!.strokeWidth;
+      if (isGeoStylerFunction(strokeWidth)) {
+        size += OlStyleUtil.evaluateNumberFunction(strokeWidth, feat);
+      } else {
+        size += strokeWidth ?? 0;
+      }
+    } else if (graphicStroke!.kind === 'Icon') {
+      const iconSize = graphicStroke!.size;
+      if (isGeoStylerFunction(iconSize)) {
+        size = OlStyleUtil.evaluateNumberFunction(iconSize, feat);
+      } else {
+        size = iconSize ?? 0;
+      }
+    }
+    return size;
   }
 
   /**

--- a/src/Util/OlGraphicStrokeUtil.spec.ts
+++ b/src/Util/OlGraphicStrokeUtil.spec.ts
@@ -1,0 +1,544 @@
+import OlGraphicStrokeUtil from './OlGraphicStrokeUtil';
+import OlLineString from 'ol/geom/LineString';
+import OlGeomPoint from 'ol/geom/Point';
+import { Style, MarkSymbolizer } from 'geostyler-style';
+
+describe('OlGraphicStrokeUtil', () => {
+
+  it('OlGraphicStrokeUtil is defined', () => {
+    expect(OlGraphicStrokeUtil).toBeDefined();
+  });
+
+  describe('containsGraphicStroke', () => {
+    it('returns true when style contains graphic stroke', () => {
+      const style: Style = {
+        name: 'Test Style',
+        rules: [{
+          name: 'Test Rule',
+          symbolizers: [{
+            kind: 'Line',
+            color: '#000000',
+            graphicStroke: {
+              kind: 'Mark',
+              wellKnownName: 'circle'
+            } as MarkSymbolizer
+          }]
+        }]
+      };
+      const result = OlGraphicStrokeUtil.containsGraphicStroke(style);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when style does not contain graphic stroke', () => {
+      const style: Style = {
+        name: 'Test Style',
+        rules: [{
+          name: 'Test Rule',
+          symbolizers: [{
+            kind: 'Line',
+            color: '#000000'
+          }]
+        }]
+      };
+      const result = OlGraphicStrokeUtil.containsGraphicStroke(style);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getSegmentRotation', () => {
+
+    it('returns 0 for horizontal line pointing right', () => {
+      const start = [0, 0];
+      const end = [10, 0];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(0, 5);
+    });
+
+    it('returns -180 for horizontal line pointing left', () => {
+      const start = [10, 0];
+      const end = [0, 0];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(-180, 5);
+    });
+
+    it('returns -90 for vertical line pointing up', () => {
+      const start = [0, 0];
+      const end = [0, 10];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(-90, 5);
+    });
+
+    it('returns 90 for vertical line pointing down', () => {
+      const start = [0, 10];
+      const end = [0, 0];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(90, 5);
+    });
+
+    it('returns -45 for diagonal line (northeast)', () => {
+      const start = [0, 0];
+      const end = [10, 10];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(-45, 5);
+    });
+
+    it('returns -135 for diagonal line (northwest)', () => {
+      const start = [10, 0];
+      const end = [0, 10];
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      expect(rotation).toBeCloseTo(-135, 5);
+    });
+  });
+
+  describe('getSegmentRotations', () => {
+    it('returns correct rotations for a simple line with one segment', () => {
+      const geom = new OlLineString([[0, 0], [10, 0]]);
+      const rotations = OlGraphicStrokeUtil.getSegmentRotations(geom);
+      expect(rotations).toHaveLength(1);
+      expect(rotations[0]).toBeCloseTo(0, 5);
+    });
+    it('returns correct rotations for a simple line with two segments', () => {
+      const geom = new OlLineString([[0, 0], [10, 0], [10, 10]]);
+      const rotations = OlGraphicStrokeUtil.getSegmentRotations(geom);
+      expect(rotations).toHaveLength(2);
+      expect(rotations[0]).toBeCloseTo(0, 5);
+      expect(rotations[1]).toBeCloseTo(-90, 5);
+    });
+  });
+
+  describe('getPatternSize', () => {
+    it('calculates pattern size correctly for simple dash array', () => {
+      const dashArray = [10, 5];
+      const resolution = 2;
+      const patternSize = OlGraphicStrokeUtil.getPatternSize(dashArray, resolution);
+      expect(patternSize).toBe(30); // (10 + 5) * 2
+    });
+
+    it('calculates pattern size correctly for complex dash array', () => {
+      const dashArray = [10, 5, 2, 3];
+      const resolution = 1;
+      const patternSize = OlGraphicStrokeUtil.getPatternSize(dashArray, resolution);
+      expect(patternSize).toBe(20); // (10 + 5 + 2 + 3) * 1
+    });
+
+    it('returns 0 for empty dash array', () => {
+      const dashArray: number[] = [];
+      const resolution = 2;
+      const patternSize = OlGraphicStrokeUtil.getPatternSize(dashArray, resolution);
+      expect(patternSize).toBe(0);
+    });
+
+    it('handles different resolutions correctly', () => {
+      const dashArray = [8, 2];
+      const resolution = 0.5;
+      const patternSize = OlGraphicStrokeUtil.getPatternSize(dashArray, resolution);
+      expect(patternSize).toBe(5); // (8 + 2) * 0.5
+    });
+  });
+
+  describe('getSegmentFractions', () => {
+    it('returns correct fractions for line', () => {
+      const geom = new OlLineString([[0, 0], [10, 0], [20, 0]]);
+      const fractions = OlGraphicStrokeUtil.getSegmentFractions(geom);
+      expect(fractions).toHaveLength(2);
+      expect(fractions[0]).toBeCloseTo(0.5, 5);
+      expect(fractions[1]).toBeCloseTo(1.0, 5);
+    });
+
+    it('returns cumulative fractions', () => {
+      const geom = new OlLineString([[0, 0], [10, 0], [20, 0], [30, 0]]);
+      const fractions = OlGraphicStrokeUtil.getSegmentFractions(geom);
+      expect(fractions).toHaveLength(3);
+      expect(fractions[0]).toBeCloseTo(1/3, 5);
+      expect(fractions[1]).toBeCloseTo(2/3, 5);
+      expect(fractions[2]).toBeCloseTo(1.0, 5);
+    });
+  });
+
+  describe('getDashAsFractions', () => {
+    it('converts dash array to fractions correctly', () => {
+      const dashArray = [10, 5];
+      const resolution = 1;
+      const lineLength = 100;
+      const fractions = OlGraphicStrokeUtil.getDashAsFractions(dashArray, resolution, lineLength);
+      expect(fractions).toHaveLength(2);
+      expect(fractions[0]).toBeCloseTo(0.1, 5);
+      expect(fractions[1]).toBeCloseTo(0.05, 5);
+    });
+
+    it('handles different resolutions', () => {
+      const dashArray = [20, 10];
+      const resolution = 2;
+      const lineLength = 100;
+      const fractions = OlGraphicStrokeUtil.getDashAsFractions(dashArray, resolution, lineLength);
+      expect(fractions).toHaveLength(2);
+      expect(fractions[0]).toBeCloseTo(0.4, 5);
+      expect(fractions[1]).toBeCloseTo(0.2, 5);
+    });
+  });
+
+  describe('tryAddTick', () => {
+    it('adds tick when fraction is valid (between 0 and 1)', () => {
+      const ticks: number[] = [];
+      const result = OlGraphicStrokeUtil.tryAddTick(ticks, 0.5, 0.1, 0.3);
+      expect(result).toBe(true);
+      expect(ticks).toHaveLength(1);
+      expect(ticks[0]).toBe(0.5);
+    });
+
+    it('does not add tick when right edge is greater than 1', () => {
+      const ticks: number[] = [];
+      const result = OlGraphicStrokeUtil.tryAddTick(ticks, 0.5, 0.1, 1.3);
+      expect(result).toBe(false);
+      expect(ticks).toHaveLength(0);
+    });
+
+    it('does not add tick when left edge is smaller than 0', () => {
+      const ticks: number[] = [];
+      const result = OlGraphicStrokeUtil.tryAddTick(ticks, 0.1, -0.1, 0.3);
+      expect(result).toBe(true); // Returns true but doesn't add
+      expect(ticks).toHaveLength(0);
+    });
+
+    it('adds tick with right edge at exactly 1.0', () => {
+      const ticks: number[] = [];
+      const result = OlGraphicStrokeUtil.tryAddTick(ticks, 0.5, 0.1, 1);
+      expect(result).toBe(true);
+      expect(ticks).toHaveLength(1);
+      expect(ticks[0]).toBe(0.5);
+    });
+
+    it('adds tick with left edge at exactly 0', () => {
+      const ticks: number[] = [];
+      const result = OlGraphicStrokeUtil.tryAddTick(ticks, 0.5, 0, 0.3);
+      expect(result).toBe(true);
+      expect(ticks).toHaveLength(1);
+      expect(ticks[0]).toBe(0.5);
+    });
+  });
+
+  describe('getTickFractionsWithoutDash', () => {
+    it('returns correct tick fractions for line', () => {
+      const symbolSizeFraction = 0.2;
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithoutDash(symbolSizeFraction);
+      expect(ticks).toHaveLength(5);
+      expect(ticks[0]).toBeCloseTo(0.1, 5);
+      expect(ticks[1]).toBeCloseTo(0.3, 5);
+      expect(ticks[2]).toBeCloseTo(0.5, 5);
+      expect(ticks[3]).toBeCloseTo(0.7, 5);
+      expect(ticks[4]).toBeCloseTo(0.9, 5);
+    });
+  });
+
+  describe('getTickFractionsWithDash', () => {
+    it('returns ticks only in dash portions, not gaps', () => {
+      const dashArray = [2, 1]; // 2px dash, 1px gap
+      const resolution = 1;
+      const lineLength = 5;
+      const symbolSizeFraction = 0.2; // 4 units
+      const offsetFraction = 0;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray, resolution, lineLength, symbolSizeFraction, offsetFraction
+      );
+
+      expect(ticks).toHaveLength(4);
+      expect(ticks[0]).toBeCloseTo(0.1, 2);
+      expect(ticks[1]).toBeCloseTo(0.3, 2);
+      expect(ticks[2]).toBeCloseTo(0.7, 2);
+      expect(ticks[3]).toBeCloseTo(0.9, 2);
+    });
+
+    it('uses the correct dash size, even if symbol size does not fit perfectly', () => {
+      const dashArray = [2.5, 1]; // 2.5px dash, 1px gap
+      const resolution = 1;
+      const lineLength = 5;
+      const symbolSizeFraction = 0.2; // 4 units
+      const offsetFraction = 0;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray, resolution, lineLength, symbolSizeFraction, offsetFraction
+      );
+
+      expect(ticks).toHaveLength(3);
+      expect(ticks[0]).toBeCloseTo(0.1, 2);
+      expect(ticks[1]).toBeCloseTo(0.3, 2);
+      expect(ticks[2]).toBeCloseTo(0.8, 2);
+    });
+
+    it('handles odd-length dash arrays by duplicating', () => {
+      const dashArray = [2]; // Should become [2, 2]
+      const resolution = 1;
+      const lineLength = 5;
+      const symbolSizeFraction = 0.2;
+      const offsetFraction = 0;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray, resolution, lineLength, symbolSizeFraction, offsetFraction
+      );
+
+      expect(ticks.length).toBeGreaterThan(0);
+    });
+
+    it('handles offset correctly', () => {
+      const dashArray = [2, 2];
+      const resolution = 1;
+      const lineLength = 5;
+      const symbolSizeFraction = 0.2;
+      const offsetFraction = 0.1;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray, resolution, lineLength, symbolSizeFraction, offsetFraction
+      );
+
+      // First tick should be offset
+      expect(ticks.length).toBeGreaterThan(0);
+      expect(ticks[0]).toBeCloseTo(0.2, 5);
+    });
+
+    it('stops at line end', () => {
+      const dashArray = [2, 1];
+      const resolution = 1;
+      const lineLength = 5;
+      const symbolSizeFraction = 0.2;
+      const offsetFraction = 0;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray, resolution, lineLength, symbolSizeFraction, offsetFraction
+      );
+
+      ticks.forEach(tick => {
+        expect(tick).toBeLessThan(1);
+      });
+    });
+  });
+
+  describe('#getTickFractions', () => {
+    it('is defined', () => {
+      expect(OlGraphicStrokeUtil.getTickFractions).toBeDefined();
+    });
+
+    it('returns empty array when symbol size is zero', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 0;
+      const resolution = 1;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractions(geom, symbolSize, resolution);
+      expect(ticks).toHaveLength(0);
+    });
+
+    it('returns empty array when symbol size is negative', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = -10;
+      const resolution = 1;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractions(geom, symbolSize, resolution);
+      expect(ticks).toHaveLength(0);
+    });
+
+    it('calls getTickFractionsWithoutDash when no dash array provided', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 10;
+      const resolution = 1;
+
+      const spy = jest.spyOn(OlGraphicStrokeUtil, 'getTickFractionsWithoutDash');
+      OlGraphicStrokeUtil.getTickFractions(geom, symbolSize, resolution);
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('calls getTickFractionsWithDash when dash array is provided', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 10;
+      const resolution = 1;
+      const dashArray = [10, 5];
+
+      const spy = jest.spyOn(OlGraphicStrokeUtil, 'getTickFractionsWithDash');
+      OlGraphicStrokeUtil.getTickFractions(geom, symbolSize, resolution, dashArray);
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('handles dash offset parameter', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 10;
+      const resolution = 1;
+      const dashArray = [10, 5];
+      const dashOffset = 5;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractions(
+        geom, symbolSize, resolution, dashArray, dashOffset
+      );
+
+      expect(ticks.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns ticks for simple case without dash', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 20;
+      const resolution = 1;
+
+      const ticks = OlGraphicStrokeUtil.getTickFractions(geom, symbolSize, resolution);
+      expect(ticks.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('#processLineStringGraphicStroke', () => {
+    it('is defined', () => {
+      expect(OlGraphicStrokeUtil.processLineStringGraphicStroke).toBeDefined();
+    });
+
+    it('generates styles for each tick position', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 20;
+      const resolution = 1;
+      const dashArray = undefined;
+      const evaluatedDashOffset = 0;
+      const evaluatedSymbolRotation = 0;
+      const graphicStroke = {
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        radius: 5
+      };
+
+      const mockStyle = {
+        clone: jest.fn().mockReturnThis(),
+        setGeometry: jest.fn()
+      };
+
+      const symbolizerGenerator = jest.fn().mockReturnValue(mockStyle);
+
+      const styles = OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        geom,
+        symbolSize,
+        resolution,
+        dashArray,
+        evaluatedDashOffset,
+        evaluatedSymbolRotation,
+        graphicStroke,
+        symbolizerGenerator,
+        OlGeomPoint
+      );
+
+      expect(styles.length).toBeGreaterThan(0);
+      expect(symbolizerGenerator).toHaveBeenCalled();
+    });
+
+    it('applies rotation to graphic stroke', () => {
+      const geom = new OlLineString([[0, 0], [100, 0], [100, 100]]);
+      const symbolSize = 50;
+      const resolution = 1;
+      const dashArray = undefined;
+      const evaluatedDashOffset = 0;
+      const evaluatedSymbolRotation = 45;
+      const graphicStroke = {
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        radius: 5
+      };
+
+      const mockStyle = {
+        clone: jest.fn().mockReturnThis(),
+        setGeometry: jest.fn()
+      };
+
+      const symbolizerGenerator = jest.fn().mockReturnValue(mockStyle);
+
+      OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        geom,
+        symbolSize,
+        resolution,
+        dashArray,
+        evaluatedDashOffset,
+        evaluatedSymbolRotation,
+        graphicStroke,
+        symbolizerGenerator,
+        OlGeomPoint
+      );
+
+      // Check that symbolizerGenerator was called with rotated graphics
+      const calls = symbolizerGenerator.mock.calls;
+      calls.forEach(call => {
+        const modifiedGraphic = call[0];
+        expect(modifiedGraphic.rotate).toBeDefined();
+      });
+    });
+
+    it('creates Point geometries at tick positions', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 50;
+      const resolution = 1;
+      const dashArray = undefined;
+      const evaluatedDashOffset = 0;
+      const evaluatedSymbolRotation = 0;
+      const graphicStroke = {
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        radius: 5
+      };
+
+      const mockStyle = {
+        clone: jest.fn().mockReturnThis(),
+        setGeometry: jest.fn()
+      };
+
+      const symbolizerGenerator = jest.fn().mockReturnValue(mockStyle);
+
+      OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        geom,
+        symbolSize,
+        resolution,
+        dashArray,
+        evaluatedDashOffset,
+        evaluatedSymbolRotation,
+        graphicStroke,
+        symbolizerGenerator,
+        OlGeomPoint
+      );
+
+      expect(mockStyle.setGeometry).toHaveBeenCalled();
+      const setGeometryCalls = mockStyle.setGeometry.mock.calls;
+      setGeometryCalls.forEach(call => {
+        const geomArg = call[0];
+        expect(geomArg).toBeInstanceOf(OlGeomPoint);
+      });
+    });
+
+    it('handles dash array parameter', () => {
+      const geom = new OlLineString([[0, 0], [100, 0]]);
+      const symbolSize = 10;
+      const resolution = 1;
+      const dashArray = [20, 10];
+      const evaluatedDashOffset = 0;
+      const evaluatedSymbolRotation = 0;
+      const graphicStroke = {
+        kind: 'Mark',
+        wellKnownName: 'circle',
+        radius: 5
+      };
+
+      const mockStyle = {
+        clone: jest.fn().mockReturnThis(),
+        setGeometry: jest.fn()
+      };
+
+      const symbolizerGenerator = jest.fn().mockReturnValue(mockStyle);
+
+      const styles = OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        geom,
+        symbolSize,
+        resolution,
+        dashArray,
+        evaluatedDashOffset,
+        evaluatedSymbolRotation,
+        graphicStroke,
+        symbolizerGenerator,
+        OlGeomPoint
+      );
+
+      expect(styles.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/Util/OlGraphicStrokeUtil.ts
+++ b/src/Util/OlGraphicStrokeUtil.ts
@@ -1,0 +1,305 @@
+import {
+  Style,
+} from 'geostyler-style';
+
+import OlGeomPoint from 'ol/geom/Point';
+import OlLineString from 'ol/geom/LineString';
+import { Coordinate } from 'ol/coordinate';
+
+/**
+ * Offers some utility functions to work with OpenLayers Graphic Strokes.
+ */
+class OlGraphicStrokeUtil {
+
+  /**
+   * Check if the given style contains a graphic stroke in any of its rules.
+   * @param style The style to check.
+   * @returns True if the style contains a graphic stroke, false otherwise.
+   */
+  public static containsGraphicStroke(style: Style) {
+    return style.rules.some(rule =>
+      rule.symbolizers?.some(
+        symbolizer => symbolizer.kind === 'Line' && symbolizer.graphicStroke
+      )
+    );
+  }
+
+  /**
+   * Get the rotation in degrees for a line segment defined by its start and
+   * end coordinates.
+   * @param start The start coordinate of the line segment.
+   * @param end The end coordinate of the line segment.
+   * @returns The rotation in degrees.
+   */
+  public static getSegmentRotation(start: Coordinate, end: Coordinate) {
+    // taken from https://openlayers.org/en/latest/examples/line-arrows.html
+    const dx = end[0] - start[0];
+    const dy = end[1] - start[1];
+    const rotation = Math.atan2(dy, dx);
+    const RADIANS_TO_DEGREES = 180 / Math.PI;
+    return -rotation * RADIANS_TO_DEGREES;
+  }
+
+  /**
+   * Get the rotations in degrees for each segment of a LineString geometry.
+   * @param geom The LineString geometry
+   * @returns An array of rotations in degrees for each segment
+   */
+  public static getSegmentRotations(geom: OlLineString) {
+    const segmentRotations: number[] = [];
+    geom.forEachSegment((start, end) => {
+      const rotation = OlGraphicStrokeUtil.getSegmentRotation(start, end);
+      segmentRotations.push(rotation);
+    });
+    return segmentRotations;
+  }
+
+  /**
+   * Get the total size of a dash pattern in map units.
+   * @param dashArray The dash array in pixels.
+   * @param resolution The map resolution.
+   * @returns The total size of the dash pattern in map units.
+   */
+  public static getPatternSize(
+    dashArray: number[],
+    resolution: number
+  ) {
+    const patternSizePx = dashArray.reduce((sum, value) => sum + value, 0);
+    const patternSizeMapUnit = resolution * patternSizePx;
+    return patternSizeMapUnit;
+  }
+
+  /**
+   * Get the normalized fractions along the line where each segment ends.
+   * @param geom The LineString geometry
+   * @returns An array of normalized fractions
+   */
+  public static getSegmentFractions(geom: OlLineString) {
+    // creates a list of normalized fractions, where each segment ends
+    // e.g. [0.3, 0.6, 1.0] for a line with 3 segments of equal length
+    const segmentFractions: number[] = [];
+    const lineLength = geom.getLength();
+    let currentTotal = 0;
+    geom.forEachSegment((start, end) => {
+      const segment = new OlLineString([start, end]);
+      const segmentLength = segment.getLength();
+      const segmentFraction = segmentLength / lineLength;
+      currentTotal += segmentFraction;
+      segmentFractions.push(currentTotal);
+    });
+    return segmentFractions;
+  }
+
+  /**
+   * Get the dash array as fractions of the total line length.
+   * @param dashArray The dash array in pixels.
+   * @param resolution The map resolution.
+   * @param lineLength The total length of the line in map units.
+   * @returns An array of fractions representing the dash lengths relative
+   * to the line length.
+   */
+  public static getDashAsFractions(
+    dashArray: number[],
+    resolution: number,
+    lineLength: number
+  ) {
+    const dashToFraction = (dash: number) => (dash * resolution) / lineLength;
+    return dashArray.map(dash => dashToFraction(dash));
+  }
+
+  /**
+   * Get the fractions along the line where ticks should be placed, considering
+   * the symbol size, resolution, and optional dash pattern.
+   * @param geom The LineString geometry
+   * @param symbolSize The size of the symbol in pixels
+   * @param resolution The map resolution
+   * @param dashArray Optional dash array
+   * @param dashOffset Optional dash offset
+   * @returns An array of fractions along the line where ticks should be placed
+   */
+  public static getTickFractions(
+    geom: OlLineString,
+    symbolSize: number,
+    resolution: number,
+    dashArray?: number[],
+    dashOffset?: number
+  ) {
+    if (symbolSize <= 0) {
+      return [];
+    }
+
+    const lineLength = geom.getLength();
+    const symbolSizeFraction = (symbolSize * resolution) / lineLength;
+    const offsetFraction = (dashOffset ? dashOffset * resolution : 0) / lineLength;
+
+    const hasDashArray = dashArray && dashArray.length > 0;
+    if (hasDashArray) {
+      return OlGraphicStrokeUtil.getTickFractionsWithDash(
+        dashArray,
+        resolution,
+        lineLength,
+        symbolSizeFraction,
+        offsetFraction
+      );
+    }
+
+    return OlGraphicStrokeUtil.getTickFractionsWithoutDash(
+      symbolSizeFraction
+    );
+  }
+
+  /**
+   * Helper method to add a tick at the given fraction if it's within valid bounds.
+   * @param ticks Array to add the tick to
+   * @param currentFraction The fraction to potentially add
+   * @returns True if the tick was added and we should continue, false if we've exceeded bounds
+   */
+  public static tryAddTick(ticks: number[], currentFraction: number, leftEdge: number, rightEdge: number): boolean {
+    if (rightEdge > 1) {
+      return false;
+    }
+    // Only add ticks with non-negative fractions (in case of negative offset)
+    if (leftEdge >= 0) {
+      ticks.push(currentFraction);
+    }
+    return true;
+  }
+
+  /**
+   * Get tick fractions for a line without a dash pattern.
+   * @param symbolSizeFraction The symbol size as a fraction of the line length
+   * @param offsetFraction The offset as a fraction of the line length
+   * @returns An array of fractions along the line where ticks should be placed
+   */
+  public static getTickFractionsWithoutDash(
+    symbolSizeFraction: number
+  ): number[] {
+    const ticks: number[] = [];
+    const symbolRadiusFraction = symbolSizeFraction / 2;
+    let currentFraction = symbolRadiusFraction;
+
+    while (true) {
+      const nextFraction = currentFraction + symbolSizeFraction;
+      const leftEdge = currentFraction - symbolRadiusFraction;
+      const rightEdge = currentFraction + symbolRadiusFraction;
+      const addedTick = OlGraphicStrokeUtil.tryAddTick(ticks, currentFraction, leftEdge, rightEdge);
+      currentFraction = nextFraction;
+      if (!addedTick) {
+        break;
+      }
+    }
+
+    return ticks;
+  }
+
+  /**
+   * Get tick fractions for a line with a dash pattern.
+   * @param dashArray The dash array in pixels
+   * @param resolution The map resolution
+   * @param lineLength The total length of the line in map units
+   * @param symbolSizeFraction The symbol size as a fraction of the line length
+   * @param offsetFraction The offset as a fraction of the line length
+   * @returns An array of fractions along the line where ticks should be placed
+   */
+  public static getTickFractionsWithDash(
+    dashArray: number[],
+    resolution: number,
+    lineLength: number,
+    symbolSizeFraction: number,
+    offsetFraction: number
+  ): number[] {
+    // Duplicate dash array if it has an odd number of elements
+    const normalizedDash = dashArray.length % 2 === 0 ? dashArray : [...dashArray, ...dashArray];
+    const dashFractions = OlGraphicStrokeUtil.getDashAsFractions(normalizedDash, resolution, lineLength);
+    const symbolRadiusFraction = symbolSizeFraction / 2;
+
+    const ticks: number[] = [];
+    // Start at the initial offset plus half a symbol size to position the
+    // first symbol directly at the beginning of the line.
+    let currentFraction = offsetFraction + symbolRadiusFraction;
+    let dashIndex = 0;
+
+    while (currentFraction <= 1) {
+      const isGap = dashIndex % 2 === 1;
+      const dashItemFraction = dashFractions[dashIndex];
+
+      if (isGap) {
+        currentFraction += dashItemFraction;
+      } else {
+        const symbolsInDraw = dashItemFraction / symbolSizeFraction;
+        const fullSymbolsInDraw = Math.floor(symbolsInDraw);
+        for (let i = 0; i < fullSymbolsInDraw; i++) {
+          const leftEdge = currentFraction - symbolRadiusFraction;
+          const rightEdge = currentFraction + symbolRadiusFraction;
+          const nextFraction = currentFraction + symbolSizeFraction;
+          const addedTick = OlGraphicStrokeUtil.tryAddTick(ticks, currentFraction, leftEdge, rightEdge);
+          currentFraction = nextFraction;
+          if (!addedTick) {
+            return ticks;
+          }
+        }
+        // leftover part that does not fit a whole symbol, but still needs to
+        // be added for correct offsetting of the next dash item
+        const leftOver = (symbolsInDraw % 1) * symbolSizeFraction;
+        currentFraction += leftOver;
+      }
+
+      // Cycle through the dash pattern
+      dashIndex = (dashIndex + 1) % dashFractions.length;
+    }
+
+    return ticks;
+  }
+
+  /**
+   * Process a single LineString geometry to generate graphic stroke styles.
+   *
+   * @param geom The LineString geometry to process
+   * @param symbolSize The size of the symbol in pixels
+   * @param resolution The map resolution
+   * @param dashArray Optional dash array for dashed patterns
+   * @param evaluatedDashOffset Evaluated dash offset value
+   * @param evaluatedSymbolRotation Evaluated symbol rotation in degrees
+   * @param graphicStroke The graphic stroke point symbolizer
+   * @param symbolizerGenerator Function to generate OL styles from a modified graphic stroke
+   * @param PointConstructor Constructor for creating OL Point geometries
+   * @returns Array of OL styles for the graphic stroke
+   */
+  public static processLineStringGraphicStroke(
+    geom: OlLineString,
+    symbolSize: number,
+    resolution: number,
+    dashArray: number[] | undefined,
+    evaluatedDashOffset: number,
+    evaluatedSymbolRotation: number,
+    graphicStroke: any,
+    symbolizerGenerator: (modifiedGraphicStroke: any) => any,
+    PointConstructor: typeof OlGeomPoint
+  ): any[] {
+    const tickFractions = OlGraphicStrokeUtil.getTickFractions(
+      geom, symbolSize, resolution, dashArray, evaluatedDashOffset
+    );
+    const segmentFractions = OlGraphicStrokeUtil.getSegmentFractions(geom);
+    const segmentRotations = OlGraphicStrokeUtil.getSegmentRotations(geom);
+
+    const segmentStyles = segmentRotations.map((segmentRotation) => {
+      const rotation = segmentRotation + evaluatedSymbolRotation;
+      const graphicStrokeClone = structuredClone(graphicStroke);
+      graphicStrokeClone.rotate = rotation;
+      return symbolizerGenerator(graphicStrokeClone);
+    });
+
+    return tickFractions.map(tickFraction => {
+      const coord = geom.getCoordinateAt(tickFraction);
+      const tick = new PointConstructor(coord);
+      const segmentIndex = segmentFractions.findIndex(
+        segmentFraction => tickFraction <= segmentFraction
+      );
+      const styleClone = segmentStyles[segmentIndex].clone();
+      styleClone.setGeometry(tick);
+      return styleClone;
+    });
+  }
+}
+
+export default OlGraphicStrokeUtil;

--- a/src/Util/OlSvgPoints.ts
+++ b/src/Util/OlSvgPoints.ts
@@ -1,6 +1,53 @@
 import { MarkSymbolizer } from 'geostyler-style';
 import OlStyleUtil from './OlStyleUtil';
-import { LINE_WELLKNOWNNAMES, NOFILL_WELLKNOWNNAMES, svgDefinition } from './OlSvgUtil';
+import { getSvgSizes, LINE_WELLKNOWNNAMES, NOFILL_WELLKNOWNNAMES, svgDefinition } from './OlSvgUtil';
+
+// The sizes in viewbox units for the different SVGs. This currently assumes
+// square SVGs.
+export const SVG_SIZES: Record<string, number> = {
+  arrow: 20,
+  arrowhead: 20,
+  asterisk_fill: 20,
+  backslash: 24,
+  carrow: 20,
+  circle: 20,
+  cross: 24,
+  cross_fill: 20,
+  cross2: 24,
+  decagon: 20,
+  diagonal_half_square: 20,
+  diamond: 20,
+  equilateral_triangle: 20,
+  filled_arrowhead: 20,
+  half_arc: 20,
+  half_square: 20,
+  heart: 20,
+  hexagon: 20,
+  horline: 24,
+  left_half_triangle: 20,
+  line: 24,
+  oarrow: 20,
+  octagon: 20,
+  parallelogram_left: 20,
+  parallelogram_right: 20,
+  pentagon: 20,
+  quarter_arc: 20,
+  quarter_circle: 20,
+  quarter_square: 20,
+  right_half_triangle: 20,
+  rounded_square: 20,
+  semi_circle: 20,
+  shield: 20,
+  slash: 24,
+  square: 20,
+  square_with_corners: 20,
+  star: 20,
+  star_diamond: 20,
+  third_arc: 20,
+  third_circle: 20,
+  trapezoid: 20,
+  triangle: 20
+};
 
 // Shape definitions, all are roughly scaled to 20x20 in coordinates between (-10,-10) to (10,10)
 export const pointSvgs: svgDefinition = {
@@ -84,19 +131,26 @@ export const isPointDefinedAsSvg = (wellKnownName: string) => cleanWellKnownName
 export const getPointSvg = (
   symbolizer: MarkSymbolizer
 ) => {
-  const { wellKnownName, radius, color, fillOpacity, strokeColor, strokeWidth, strokeOpacity } = symbolizer;
-  const dimensions = (radius as number ?? 6) * 2;  // Default to 12 pixels
-
+  const { wellKnownName, radius = 6, color, fillOpacity, strokeColor, strokeWidth, strokeOpacity } = symbolizer;
   if (!isPointDefinedAsSvg(wellKnownName)) {
     throw new Error('Unknown wellKnownName: ' + wellKnownName);
   }
 
   const cleanedWellKnownName = cleanWellKnownName(wellKnownName);
 
+  const defaultedStrokeWidth = strokeWidth ?? 1;
+
+  const svgSize = SVG_SIZES[cleanedWellKnownName];
+  const {
+    minV,
+    sizeV,
+    heightPx
+  } = getSvgSizes(radius as number, defaultedStrokeWidth as number, svgSize);
+
   const svgHeader = '<svg xmlns="http://www.w3.org/2000/svg" ' +
-    'width="' + dimensions + '" ' +
-    'height="' + dimensions + '" ' +
-    'viewBox="-12 -12 24 24">';
+    'width="' + heightPx + '" ' +
+    'height="' + heightPx + '" ' +
+    `viewBox="${minV} ${minV} ${sizeV} ${sizeV}">`;
   const svgFooter = '</svg>';
 
   let svgBody = pointSvgs[cleanedWellKnownName] + ' ';
@@ -125,7 +179,7 @@ export const getPointSvg = (
     svgStyle += 'stroke:' + strokeColor + '; ';
   };
   if (strokeWidth) {
-    const scaleFactor = dimensions / 24;
+    const scaleFactor = heightPx / sizeV;
     svgStyle += 'stroke-width:' + Number(strokeWidth) / scaleFactor + '; ';
   };
   if (OlStyleUtil.checkOpacity(strokeOpacity)) {

--- a/src/Util/OlSvgUtil.spec.ts
+++ b/src/Util/OlSvgUtil.spec.ts
@@ -1,0 +1,109 @@
+import { getSvgSizes, getSizesFromSvg } from './OlSvgUtil';
+
+describe('OlSvgUtil', () => {
+
+  describe('getSvgSizes', () => {
+
+    it('calculates correct sizes for basic input', () => {
+      const radius = 10;
+      const strokeWidth = 2;
+      const unpaddedSizeSimpleV = 20;
+
+      const result = getSvgSizes(radius, strokeWidth, unpaddedSizeSimpleV);
+
+      expect(result).toBeDefined();
+      expect(result.minV).toBeCloseTo(-12);
+      expect(result.sizeV).toBeCloseTo(24);
+      expect(result.heightPx).toBeCloseTo(24);
+    });
+
+    it('handles zero stroke width', () => {
+      const radius = 15;
+      const strokeWidth = 0;
+      const unpaddedSizeSimpleV = 30;
+
+      const result = getSvgSizes(radius, strokeWidth, unpaddedSizeSimpleV);
+
+      // With zero stroke width, padding should still include clipping padding
+      expect(result.minV).toBeCloseTo(-15);
+      expect(result.sizeV).toBeCloseTo(30);
+      expect(result.heightPx).toBeCloseTo(30);
+    });
+
+    it('handles different viewBox scaling', () => {
+      const radius = 20;
+      const strokeWidth = 3;
+      const unpaddedSizeSimpleV = 100; // Different scale
+
+      const result = getSvgSizes(radius, strokeWidth, unpaddedSizeSimpleV);
+
+      expect(result.minV).toBeCloseTo(-57.5);
+      expect(result.sizeV).toBeCloseTo(115);
+      expect(result.heightPx).toBeCloseTo(46);
+    });
+
+    it('handles large stroke width', () => {
+      const radius = 10;
+      const strokeWidth = 100;
+      const unpaddedSizeSimpleV = 20;
+
+      const result = getSvgSizes(radius, strokeWidth, unpaddedSizeSimpleV);
+
+      expect(result.minV).toBeCloseTo(-110);
+      expect(result.sizeV).toBeCloseTo(220);
+      expect(result.heightPx).toBeCloseTo(220);
+    });
+  });
+
+  describe('getSizesFromSvg', () => {
+
+    it('extracts radius and stroke width from SVG dimensions', () => {
+      const widthPx = 24;
+      const strokeWidthV = 2;
+      const viewBox = '-12 -12 24 24';
+
+      const result = getSizesFromSvg(widthPx, strokeWidthV, viewBox);
+
+      expect(result).toBeDefined();
+      expect(result.radius).toBeCloseTo(10);
+      expect(result.strokeWidth).toBeCloseTo(2);
+    });
+
+    it('correctly reverses getSvgSizes calculation', () => {
+      // Use the output from getSvgSizes as input to getSizesFromSvg
+      const originalRadius = 10;
+      const originalStrokeWidth = 2;
+      const unpaddedSizeSimpleV = 20;
+
+      const sizes = getSvgSizes(originalRadius, originalStrokeWidth, unpaddedSizeSimpleV);
+      const viewBox = `${sizes.minV} ${sizes.minV} ${sizes.sizeV} ${sizes.sizeV}`;
+
+      const result = getSizesFromSvg(sizes.heightPx, 2, viewBox);
+
+      expect(result.radius).toBeCloseTo(originalRadius, 5);
+      expect(result.strokeWidth).toBeCloseTo(originalStrokeWidth, 5);
+    });
+
+    it('handles SVG without stroke (NaN strokeWidthV)', () => {
+      const widthPx = 20;
+      const strokeWidthV = NaN;
+      const viewBox = '0 0 20 20';
+
+      const result = getSizesFromSvg(widthPx, strokeWidthV, viewBox);
+
+      expect(result.radius).toBeDefined();
+      expect(result.strokeWidth).toBeUndefined();
+    });
+
+    it('handles zero stroke width', () => {
+      const widthPx = 30;
+      const strokeWidthV = 0;
+      const viewBox = '-15 -15 30 30';
+
+      const result = getSizesFromSvg(widthPx, strokeWidthV, viewBox);
+
+      expect(result.radius).toBeGreaterThan(0);
+      expect(result.strokeWidth).toBeDefined();
+    });
+  });
+});

--- a/src/Util/OlSvgUtil.ts
+++ b/src/Util/OlSvgUtil.ts
@@ -55,11 +55,15 @@ export const getSvgProperties = (svgString: string): MarkSymbolizer | undefined 
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(svgString, 'image/svg+xml');
   const svgElement = svgDoc.querySelector('svg');
-  const width = svgElement?.getAttribute('width');
   if (!svgElement) {
     return;
   };
 
+  const width = svgElement.getAttribute('width');
+  const viewBox = svgElement.getAttribute('viewBox');
+  if (!viewBox) {
+    return;
+  }
   const firstChildElement = Array.from(svgElement.children).find((child) => {
     return child instanceof Element;
   });
@@ -67,15 +71,19 @@ export const getSvgProperties = (svgString: string): MarkSymbolizer | undefined 
   const wellKnownName = firstChildElement?.getAttribute('id') as WellKnownName;
   const styleString = firstChildElement?.getAttribute('style') ?? '';
   const styleComponents = getStyleComponents(styleString);
+  const {
+    radius,
+    strokeWidth
+  } = getSizesFromSvg(Number(width), Number(styleComponents['stroke-width']), viewBox);
 
   const symbolizer: MarkSymbolizer = {
     kind: 'Mark',
     wellKnownName,
-    radius: Number(width) / 2,
+    radius,
     ...styleComponents.fill && { color: styleComponents.fill },
     ...styleComponents['fill-opacity'] && { fillOpacity: Number(styleComponents['fill-opacity']) },
     ...styleComponents.stroke && { strokeColor: styleComponents.stroke },
-    ...styleComponents['stroke-width'] && { strokeWidth: Number(styleComponents['stroke-width']) },
+    ...styleComponents['stroke-width'] && { strokeWidth },
     ...styleComponents['stroke-opacity'] && { strokeOpacity: Number(styleComponents['stroke-opacity']) }
   };
 
@@ -350,4 +358,64 @@ const svgArcToCanvas = (
 
   // Draw the arc
   ctx.arc(cx, cy, rx, startAngle, endAngle, !sweepFlag);
+};
+
+/**
+ * Get the SVG sizes for a point symbolizer. Currently assumes square SVGs.
+ * @param radius The radius of the symbol in px
+ * @param strokeWidth The stroke width of the symbol in px
+ * @param unpaddedSizeSimpleV The unpadded size of the symbol in ViewBox units
+ * @returns An object containing the calculated SVG sizes
+ */
+export const getSvgSizes = (radius: number, strokeWidth: number, unpaddedSizeSimpleV: number) => {
+  // We add the stroke width in viewbox units twice to the unpadded size.
+  // We then recompute the viewbox in order to contain the whole shape
+  // including stroke. The height in pixels will be calculated in a way that
+  // the radius of the shape corresponds to the provided radius, i.e. the
+  // actual SVG (incl. transparent paddings) will be bigger than the provided
+  // radius.
+  const unpaddedSizeSimplePx = radius * 2;
+
+  const vPerPixel = unpaddedSizeSimpleV / unpaddedSizeSimplePx;
+  const pixelPerV = unpaddedSizeSimplePx / unpaddedSizeSimpleV;
+
+  // for some reason whe have to use the stroke width as padding for the clipping
+  const clippingPaddingPx = strokeWidth;
+  const clippingPaddingV = clippingPaddingPx * vPerPixel;
+
+  const strokeWidthV = strokeWidth * vPerPixel;
+
+  const paddingV = clippingPaddingV + strokeWidthV;
+  const paddingPx = paddingV * pixelPerV;
+
+  const sizeV = unpaddedSizeSimpleV + paddingV;
+  const minV = -(sizeV / 2);
+
+  const heightPx = unpaddedSizeSimplePx + paddingPx;
+
+  return {
+    minV,
+    sizeV,
+    heightPx
+  };
+};
+
+export const getSizesFromSvg = (widthPx: number, strokeWidthV: number, viewBox: string) => {
+  const isStroked = !Number.isNaN(strokeWidthV);
+
+  const viewBoxValues = viewBox.split(' ').map(parseFloat);
+  const sizeV = viewBoxValues[2];
+  const pixelPerV = widthPx / sizeV;
+  const vPerPixel = sizeV / widthPx;
+  const strokeV = isStroked ? strokeWidthV : vPerPixel;
+
+  const unpaddedSizeV = sizeV - 2 * strokeV;
+
+  const radius = (unpaddedSizeV / 2) * pixelPerV;
+  const strokeWidth = isStroked ? strokeV * pixelPerV : undefined;
+
+  return {
+    radius,
+    strokeWidth
+  };
 };


### PR DESCRIPTION
<!-- # Thank you 💞

Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.

## Some guidelines for the proposed change

Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.

Please use the template below the line for the pull request description, and make sure to tick off the boxes in the checklists. -->

## Description

This adds support for graphicStroke on linesymbolizers. This also includes graphic stroke with dash arrays.


mark symbolizer - arrow symbol

<img width="358" height="276" alt="image" src="https://github.com/user-attachments/assets/717c6355-33f9-4d12-b0f8-6f268d9d110a" />

mark symbolizer - rotated arrow symbol

<img width="359" height="257" alt="image" src="https://github.com/user-attachments/assets/2defa519-45bf-469b-849f-4fcbbf0ce319" />

mark symbolizer - rotated arrow symbol with dash pattern

<img width="371" height="269" alt="image" src="https://github.com/user-attachments/assets/f080a8fa-61d6-4c6c-a645-fe58fb43df0b" />

icon symbolizer - icon with dash pattern 

<img width="382" height="269" alt="image" src="https://github.com/user-attachments/assets/0df340b7-c443-45e7-babd-f51a2974dcb1" />


<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
