### PR TITLE
feat(LineSymbolizer): support graphicStroke for (multi-)polygons

### DIFF
--- a/src/OlStyleParser.spec.ts
+++ b/src/OlStyleParser.spec.ts
@@ -8,7 +8,10 @@ import OlStyleText, { Options as TextOptions } from 'ol/style/Text';
 import OlStyleFill, { Options as FillOptions } from 'ol/style/Fill';
 import OlFeature from 'ol/Feature';
 import OlLineString from 'ol/geom/LineString';
+import OlMultiLineString from 'ol/geom/MultiLineString';
 import OlPoint from 'ol/geom/Point';
+import OlPolygon from 'ol/geom/Polygon';
+import OlMultiPolygon from 'ol/geom/MultiPolygon';
 
 import OlStyleParser, { OlParserStyleFct } from './OlStyleParser';
 
@@ -905,6 +908,48 @@ describe('OlStyleParser implements StyleParser', () => {
     expect(coordsGeom2[1]).toBeCloseTo(15);
     expect(coordsGeom3[1]).toBeCloseTo(35);
     expect(coordsGeom4[1]).toBeCloseTo(45);
+  });
+  it('can write an OpenLayers LineSymbolizer with graphicStroke for MultiLineStrings', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_graphicstroke);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({
+      geometry: new OlMultiLineString([[[0, 0], [0, 20]], [[10, 0], [10, 20]]])
+    });
+    const resolution = 1;
+    const expecSymb = (line_graphicstroke.rules[0].symbolizers[0] as LineSymbolizer).graphicStroke as MarkSymbolizer;
+    const evaluatedStyle = (olStyle as unknown as OlParserStyleFct)(testFeature, resolution)[0];
+    const geometry = evaluatedStyle.getGeometry();
+    expect(geometry).toBeInstanceOf(OlPoint);
+  });
+  it('can write an OpenLayers LineSymbolizer with graphicStroke for Polygons', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_graphicstroke);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({
+      geometry: new OlPolygon([[[0, 0], [0, 20], [20, 20], [20, 0], [0, 0]]])
+    });
+    const resolution = 1;
+    const expecSymb = (line_graphicstroke.rules[0].symbolizers[0] as LineSymbolizer).graphicStroke as MarkSymbolizer;
+    const evaluatedStyle = (olStyle as unknown as OlParserStyleFct)(testFeature, resolution)[0];
+    const geometry = evaluatedStyle.getGeometry();
+    expect(geometry).toBeInstanceOf(OlPoint);
+  });
+  it('can write an OpenLayers LineSymbolizer with graphicStroke for MultiPolygons', async () => {
+    let { output: olStyle } = await styleParser.writeStyle(line_graphicstroke);
+    olStyle = olStyle as OlStyle;
+    expect(olStyle).toBeDefined();
+
+    const testFeature = new OlFeature({
+      geometry: new OlMultiPolygon([[[[0, 0], [0, 20], [20, 20], [20, 0], [0, 0]]], [[[10, 10], [10, 30], [30, 30], [30, 10], [10, 10]]]])
+    });
+    const resolution = 1;
+    const expecSymb = (line_graphicstroke.rules[0].symbolizers[0] as LineSymbolizer).graphicStroke as MarkSymbolizer;
+    const evaluatedStyle = (olStyle as unknown as OlParserStyleFct)(testFeature, resolution)[0];
+    const geometry = evaluatedStyle.getGeometry();
+    expect(geometry).toBeInstanceOf(OlPoint);
   });
   it('can write an OpenLayers PolygonSymbolizer', async () => {
     let { output: olStyle } = await styleParser.writeStyle(polygon_transparentpolygon);

--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -40,6 +40,8 @@ import OlStyleIcon, { Options as OlStyleIconOptions }  from 'ol/style/Icon';
 import OlStyleRegularshape from 'ol/style/RegularShape';
 import OlLineString from 'ol/geom/LineString';
 import OlMultiLineString from 'ol/geom/MultiLineString';
+import OlPolygon from 'ol/geom/Polygon';
+import OlMultiPolygon from 'ol/geom/MultiPolygon';
 import { METERS_PER_UNIT } from 'ol/proj/Units';
 
 import OlStyleUtil, { DEGREES_TO_RADIANS } from './Util/OlStyleUtil';
@@ -123,7 +125,6 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         roundLimit: 'none',
         spacing: 'none',
         graphicFill: 'none',
-        graphicStroke: 'none',
         perpendicularOffset: 'none'
       },
       RasterSymbolizer: 'none',
@@ -172,6 +173,8 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
   OlStyleRegularshapeConstructor = OlStyleRegularshape;
   OlLineStringContructor = OlLineString;
   OlMultiLineStringConstructor = OlMultiLineString;
+  OlPolygonConstructor = OlPolygon;
+  OlMultiPolygonConstructor = OlMultiPolygon;
   OlPointConstructor = OlGeomPoint;
 
   constructor(ol?: any) {
@@ -186,6 +189,8 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       this.OlStyleRegularshapeConstructor = ol.style.RegularShape;
       this.OlLineStringContructor = ol.geom.LineString;
       this.OlMultiLineStringConstructor = ol.geom.MultiLineString;
+      this.OlPolygonConstructor = ol.geom.Polygon;
+      this.OlMultiPolygonConstructor = ol.geom.MultiPolygon;
       this.OlPointConstructor = ol.geom.Point;
     }
   }
@@ -1255,12 +1260,12 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
   getOlGraphicStrokeFromGraphicStroke(
     symbolizer: LineSymbolizer, feat: OlFeature, resolution: number
   ) {
-    const geom = feat.getGeometry();
-    if (!geom || !(geom instanceof this.OlLineStringContructor || geom instanceof this.OlMultiLineStringConstructor)) {
-      throw new Error(
-        'GraphicStroke can only be applied to (Multi-)LineString geometries'
-      );
-    }
+    const lineStrings = OlGraphicStrokeUtil.getLineStringsFromGeometry(feat.getGeometry(), {
+      LineString: this.OlLineStringContructor,
+      MultiLineString: this.OlMultiLineStringConstructor,
+      Polygon: this.OlPolygonConstructor,
+      MultiPolygon: this.OlMultiPolygonConstructor
+    });
 
     const graphicStroke = symbolizer.graphicStroke!;
     const symbolSize = this.getSymbolSizeFromGraphicStroke(graphicStroke, feat);
@@ -1283,9 +1288,12 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       return this.getOlSymbolizerFromSymbolizer(modifiedGraphicStroke, feat, resolution);
     };
 
-    if (geom instanceof this.OlLineStringContructor) {
-      return OlGraphicStrokeUtil.processLineStringGraphicStroke(
-        geom,
+    // For every line in the MultiLineString, we start the pattern at the
+    // beginning of the line. This means that the pattern can be
+    // discontinuous at vertices where the lines connect.
+    return lineStrings.flatMap(line =>
+      OlGraphicStrokeUtil.processLineStringGraphicStroke(
+        line,
         symbolSize,
         resolution,
         dashArray,
@@ -1294,25 +1302,8 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         graphicStroke,
         symbolizerGenerator,
         this.OlPointConstructor
-      );
-    } else {
-      // For every line in the MultiLineString, we start the pattern at the
-      // beginning of the line. This means that the pattern can be
-      // discontinuous at vertices where the lines connect.
-      return geom.getLineStrings().flatMap(line =>
-        OlGraphicStrokeUtil.processLineStringGraphicStroke(
-          line,
-          symbolSize,
-          resolution,
-          dashArray,
-          evaluatedDashOffset,
-          evaluatedSymbolRotation,
-          graphicStroke,
-          symbolizerGenerator,
-          this.OlPointConstructor
-        )
-      );
-    }
+      )
+    );
   }
 
   /**

--- a/src/Util/OlGraphicStrokeUtil.spec.ts
+++ b/src/Util/OlGraphicStrokeUtil.spec.ts
@@ -1,6 +1,9 @@
 import OlGraphicStrokeUtil from './OlGraphicStrokeUtil';
 import OlLineString from 'ol/geom/LineString';
+import OlMultiLineString from 'ol/geom/MultiLineString';
 import OlGeomPoint from 'ol/geom/Point';
+import OlPolygon from 'ol/geom/Polygon';
+import OlMultiPolygon from 'ol/geom/MultiPolygon';
 import { Style, MarkSymbolizer } from 'geostyler-style';
 
 describe('OlGraphicStrokeUtil', () => {
@@ -539,6 +542,73 @@ describe('OlGraphicStrokeUtil', () => {
       );
 
       expect(styles.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+  describe('#getLineStringsFromGeometry', () => {
+    it('is defined', () => {
+      expect(OlGraphicStrokeUtil.getLineStringsFromGeometry).toBeDefined();
+    });
+    it('returns an array of LineStrings with length 1 if given a LineString', () => {
+      const geom = new OlLineString([[0, 0], [10, 0]]);
+      const constructors = {
+        LineString: OlLineString,
+        MultiLineString: OlLineString, // Not used for this test
+        Polygon: OlPolygon, // Not used for this test
+        MultiPolygon: OlMultiPolygon // Not used for this test
+      };
+      const result = OlGraphicStrokeUtil.getLineStringsFromGeometry(geom, constructors);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(OlLineString);
+    });
+    it('returns an array of LineStrings if given a MultiLineString', () => {
+      const geom = new OlMultiLineString([[[0, 0], [10, 0]], [[10, 0], [10, 10]]]);
+      const constructors = {
+        LineString: OlLineString,
+        MultiLineString: OlMultiLineString,
+        Polygon: OlPolygon,
+        MultiPolygon: OlMultiPolygon
+      };
+      const result = OlGraphicStrokeUtil.getLineStringsFromGeometry(geom, constructors);
+      expect(result).toHaveLength(2);
+      result.forEach(line => {
+        expect(line).toBeInstanceOf(OlLineString);
+      });
+    });
+    it('returns an array of LineStrings if given a Polygon', () => {
+      const geom = new OlPolygon([[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]);
+      const constructors = {
+        LineString: OlLineString,
+        MultiLineString: OlMultiLineString,
+        Polygon: OlPolygon,
+        MultiPolygon: OlMultiPolygon
+      };
+      const result = OlGraphicStrokeUtil.getLineStringsFromGeometry(geom, constructors);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(OlLineString);
+    });
+    it('returns an array of LineStrings if given a MultiPolygon', () => {
+      const geom = new OlMultiPolygon([[[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]]);
+      const constructors = {
+        LineString: OlLineString,
+        MultiLineString: OlMultiLineString,
+        Polygon: OlPolygon,
+        MultiPolygon: OlMultiPolygon
+      };
+      const result = OlGraphicStrokeUtil.getLineStringsFromGeometry(geom, constructors);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(OlLineString);
+    });
+    it('throws an error for other geometry types', () => {
+      const geom = new OlGeomPoint([0, 0]);
+      const constructors = {
+        LineString: OlLineString,
+        MultiLineString: OlMultiLineString,
+        Polygon: OlPolygon,
+        MultiPolygon: OlMultiPolygon
+      };
+      expect(() => {
+        OlGraphicStrokeUtil.getLineStringsFromGeometry(geom, constructors);
+      }).toThrow();
     });
   });
 });

--- a/src/Util/OlGraphicStrokeUtil.ts
+++ b/src/Util/OlGraphicStrokeUtil.ts
@@ -4,7 +4,11 @@ import {
 
 import OlGeomPoint from 'ol/geom/Point';
 import OlLineString from 'ol/geom/LineString';
+import OlMultiLineString from 'ol/geom/MultiLineString';
+import OlPolygon from 'ol/geom/Polygon';
+import OlMultiPolygon from 'ol/geom/MultiPolygon';
 import { Coordinate } from 'ol/coordinate';
+import { Geometry } from 'ol/geom';
 
 /**
  * Offers some utility functions to work with OpenLayers Graphic Strokes.
@@ -299,6 +303,37 @@ class OlGraphicStrokeUtil {
       styleClone.setGeometry(tick);
       return styleClone;
     });
+  }
+
+  public static getLineStringsFromGeometry(geom: Geometry | undefined, constructors: {
+    LineString: typeof OlLineString;
+    MultiLineString: typeof OlMultiLineString;
+    Polygon: typeof OlPolygon;
+    MultiPolygon: typeof OlMultiPolygon;
+  }) {
+    if (!geom) {
+      throw new Error(
+        'GraphicStroke can only be applied to features with geometries'
+      );
+    }
+    if (geom instanceof constructors.LineString) {
+      return [geom];
+    } else if (geom instanceof constructors.MultiLineString) {
+      return geom.getLineStrings();
+    } else if (geom instanceof constructors.Polygon) {
+      const linearRings = geom.getLinearRings();
+      return linearRings.map(ring => new constructors.LineString(ring.getCoordinates()));
+    } else if (geom instanceof constructors.MultiPolygon) {
+      const polygons = geom.getPolygons();
+      return polygons.flatMap(polygon => {
+        const linearRings = polygon.getLinearRings();
+        return linearRings.map(ring => new constructors.LineString(ring.getCoordinates()));
+      });
+    }
+
+    throw new Error(
+      'GraphicStroke can only be applied to (Multi-)LineString or (Multi-)Polygon geometries'
+    );
   }
 }
 


### PR DESCRIPTION
<!-- # Thank you 💞

Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.

## Some guidelines for the proposed change

Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.

Please use the template below the line for the pull request description, and make sure to tick off the boxes in the checklists. -->

## Description

This adds support for linesymbolizer graphicStroke when using (multi-)polygons.

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
