### PR TITLE
fix: evaluating geostyler functions

### DIFF
--- a/src/OlStyleParser.ts
+++ b/src/OlStyleParser.ts
@@ -845,8 +845,12 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
         let maxScale = rule?.scaleDenominator?.max;
         let isWithinScale = true;
         if (minScale || maxScale) {
-          minScale = isGeoStylerFunction(minScale) ? OlStyleUtil.evaluateNumberFunction(minScale) : minScale;
-          maxScale = isGeoStylerFunction(maxScale) ? OlStyleUtil.evaluateNumberFunction(maxScale) : maxScale;
+          minScale = isGeoStylerFunction(minScale)
+            ? OlStyleUtil.evaluateFunction(minScale, feature) as number
+            : minScale;
+          maxScale = isGeoStylerFunction(maxScale)
+            ? OlStyleUtil.evaluateFunction(maxScale, feature) as number
+            : maxScale;
           if (minScale && scale < minScale) {
             isWithinScale = false;
           }
@@ -874,7 +878,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
             }
 
             if (isGeoStylerBooleanFunction(symb.visibility)) {
-              const visibility = OlStyleUtil.evaluateBooleanFunction(symb.visibility);
+              const visibility = OlStyleUtil.evaluateFunction(symb.visibility, feature) as boolean;
               if (!visibility) {
                 styles.push(null);
               }
@@ -1275,13 +1279,13 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     }
     const symbolRotation = graphicStroke.rotate;
     const evaluatedSymbolRotation = isGeoStylerFunction(symbolRotation)
-      ? OlStyleUtil.evaluateNumberFunction(symbolRotation, feat)
+      ? OlStyleUtil.evaluateFunction(symbolRotation, feat) as number
       : symbolRotation ?? 0;
     // We currently do not support expressions for dasharrays
     const dashArray = symbolizer.dasharray as number[] | undefined;
     const dashOffset = symbolizer.dashOffset || 0;
     const evaluatedDashOffset = isGeoStylerFunction(dashOffset)
-      ? OlStyleUtil.evaluateNumberFunction(dashOffset, feat)
+      ? OlStyleUtil.evaluateFunction(dashOffset, feat) as number
       : dashOffset;
 
     const symbolizerGenerator = (modifiedGraphicStroke: any) => {
@@ -1319,7 +1323,7 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
     if (graphicStroke!.kind === 'Mark') {
       const radius = graphicStroke!.radius;
       if (isGeoStylerFunction(radius)) {
-        size = OlStyleUtil.evaluateNumberFunction(radius, feat) * 2;
+        size = (OlStyleUtil.evaluateFunction(radius, feat) as number) * 2;
       } else {
         size = (radius ?? 0) * 2;
       }
@@ -1328,14 +1332,14 @@ export class OlStyleParser implements StyleParser<OlStyleLike> {
       }
       const strokeWidth = graphicStroke!.strokeWidth;
       if (isGeoStylerFunction(strokeWidth)) {
-        size += OlStyleUtil.evaluateNumberFunction(strokeWidth, feat);
+        size += OlStyleUtil.evaluateFunction(strokeWidth, feat) as number;
       } else {
         size += strokeWidth ?? 0;
       }
     } else if (graphicStroke!.kind === 'Icon') {
       const iconSize = graphicStroke!.size;
       if (isGeoStylerFunction(iconSize)) {
-        size = OlStyleUtil.evaluateNumberFunction(iconSize, feat);
+        size = OlStyleUtil.evaluateFunction(iconSize, feat) as number;
       } else {
         size = iconSize ?? 0;
       }


### PR DESCRIPTION
<!-- # Thank you 💞

Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.

## Some guidelines for the proposed change

Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.

Please use the template below the line for the pull request description, and make sure to tick off the boxes in the checklists. -->

## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This makes use of `evaluateFunction` instead of `evaluate[type]Function` in OlStyleParser. This is done to also include the `propertyFunction` in non-string input fields. E.g. when using the `property` function in a rotation field.

Previously, this would just return the name of the property and not its value.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
