### PR TITLE
fix: ensure browser build is included in releases

### DIFF
--- a/vite.config.dist.ts
+++ b/vite.config.dist.ts
@@ -52,6 +52,6 @@ export default defineConfig({
     },
     sourcemap: false,
     outDir: 'dist',
-    emptyOutDir: true,
+    emptyOutDir: false,
   },
 });


### PR DESCRIPTION
## Description

Currently the browser build is not included in releases any more. This fixes the issue by preventing the dist-build to clean the output directory.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [x] I'm lost; why do I have to check so many boxes? Please help!
